### PR TITLE
Fix: Use stderr for logging to avoid messing up MCP stdio protocol

### DIFF
--- a/packages/mcp-server/src/logger.ts
+++ b/packages/mcp-server/src/logger.ts
@@ -4,13 +4,25 @@ export interface McpLogger {
    error: (...args: unknown[]) => void;
 }
 
+/**
+ * Creates a logger that writes to stderr only.
+ *
+ * IMPORTANT: MCP uses stdio for JSON-RPC communication. The server sends
+ * JSON responses over stdout, and the client parses them. Any non-JSON
+ * output to stdout (like console.log) will corrupt the protocol and cause
+ * parsing errors like "invalid character 'M' looking for beginning of value".
+ *
+ * All logging MUST go to stderr to avoid interfering with MCP communication.
+ */
 export function createMcpLogger(scope: string): McpLogger {
    return {
       info: (...args: unknown[]): void => {
-         console.log('[MCP][' + scope + '][INFO]', ...args);
+         // Use console.error (stderr) instead of console.log (stdout)
+         // to avoid corrupting MCP's JSON-RPC protocol on stdout
+         console.error('[MCP][' + scope + '][INFO]', ...args);
       },
       warn: (...args: unknown[]): void => {
-         console.warn('[MCP][' + scope + '][WARN]', ...args);
+         console.error('[MCP][' + scope + '][WARN]', ...args);
       },
       error: (...args: unknown[]): void => {
          console.error('[MCP][' + scope + '][ERROR]', ...args);


### PR DESCRIPTION
# PR description

Hey! 👋 This is a fix for #1 that I reported a half an hour ago. I hope this helps.

## The bug

So here's what was happening apparently: MCP uses **stdio** for JSON-RPC communication. The server sends JSON responses over stdout, and the client parses them. But the logger was using `console.log()` for info messages, which writes to **stdout**.

When `sessionLogger.info()` was called during session start, it wrote something like `[MCP][SESSION][INFO] Session started...` to stdout. The MCP client tried to parse this as JSON, but JSON must start with `{`, `[`, `"`, etc. — not `M`. So it blew up with:

```
invalid character 'M' looking for beginning of value
```

The `'M'` is literally the start of `[MCP]...` 😅

In Node.js:
- `console.log()` → stdout ❌
- `console.warn()` → **also stdout** (confusingly!) ❌  
- `console.error()` → stderr ✅

## The fix

Changed all logging in `logger.ts` to use `console.error()` which writes to stderr, keeping stdout clean for JSON-RPC only.

## Testing

Tested locally with my Tauri app (Rusty Commander) and Antigravity. Connection works now! 🎉 The agent is happily taking test screenshots now 😄 

I've also run `npm test` and `npm run standards` as requested in `README.md`.

---

Let me know if you want any changes!
