### PR TITLE
fix(bridge): handle null-prototype objects in captureLog

### DIFF
--- a/packages/tauri-plugin-mcp-bridge/src/bridge.js
+++ b/packages/tauri-plugin-mcp-bridge/src/bridge.js
@@ -66,12 +66,9 @@
                   try {
                      return JSON.stringify(a);
                   } catch(_) {
-                     // Circular reference or non-serializable (e.g. null-prototype object)
-                     try {
-                        return String(a);
-                     } catch(_) {
-                        return '[non-serializable]';
-                     }
+                     // JSON.stringify fails on circular references or null-prototype objects.
+                     // Values cannot be serialized — listing keys only.
+                     return '[non-serializable, keys only: ' + Object.keys(a).join(', ') + ']';
                   }
                })
                .join(' ');


### PR DESCRIPTION
## Summary

- `captureLog` calls `args.map(String)` which throws `Cannot convert object to primitive value` on `Object.create(null)` instances — null-prototype objects have no `toString()`
- `JSON.stringify` also fails when the object has circular references, leaving no safe path and crashing the bridge entirely

## Fix

Serialize each argument individually with a two-step fallback:

1. `JSON.stringify(a)` — handles normal objects
2. `Object.keys(a)` — handles circular refs and null-prototype objects; `Object.keys` always works regardless of prototype. Since values cannot be serialized, only keys are returned, prefixed with `[non-serializable, keys only: ...]` so the reader knows the output is partial

```js
// Before
try {
   message = args.map(function(a) {
      return typeof a === 'object' ? JSON.stringify(a) : String(a);
   }).join(' ');
} catch(e) {
   message = args.map(String).join(' '); // crashes on null-prototype objects
}

// After
message = args.map(function(a) {
   if (typeof a !== 'object' || a === null) { return String(a); }
   try { return JSON.stringify(a); }
   catch(_) { return '[non-serializable, keys only: ' + Object.keys(a).join(', ') + ']'; }
}).join(' ');
```

## Reproduction

https://github.com/Fulbert/mcp-bridge-null-proto-repro

```sh
pnpm install && pnpm tauri dev
```

Devtools open automatically. Click the button — with the bridge enabled (default) you get `Uncaught TypeError: Cannot convert object to primitive value` instead of the log. Switch to the [`fix/use-patched-bridge`](https://github.com/Fulbert/mcp-bridge-null-proto-repro/tree/fix/use-patched-bridge) branch to see it working correctly.

Fixes #9