### PR TITLE
feat: improve React compatibility, text strategy fallbacks, and auto-connect

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hypothesi/tauri-mcp-server",
+  "name": "@gruckion/tauri-mcp-server",
   "version": "0.9.0",
   "mcpName": "io.github.hypothesi/mcp-server-tauri",
   "description": "A Model Context Protocol server for use with Tauri v2 applications",
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/hypothesi/mcp-server-tauri.git",
+    "url": "https://github.com/gruckion/mcp-server-tauri.git",
     "directory": "packages/mcp-server"
   },
   "files": [

--- a/packages/mcp-server/src/driver/scripts/index.ts
+++ b/packages/mcp-server/src/driver/scripts/index.ts
@@ -65,9 +65,19 @@ export function buildTypeScript(selector: string, text: string, strategy?: strin
          if (!element) throw new Error('Element not found: ' + selector);
 
          element.focus();
-         element.value = text;
-         element.dispatchEvent(new Event('input', { bubbles: true }));
-         element.dispatchEvent(new Event('change', { bubbles: true }));
+
+         // Use native prototype setter to bypass React's value tracker
+         var proto = element.tagName === 'TEXTAREA'
+            ? HTMLTextAreaElement.prototype
+            : HTMLInputElement.prototype;
+         var nativeSetter = Object.getOwnPropertyDescriptor(proto, 'value').set;
+         nativeSetter.call(element, text);
+
+         // Reset React's internal value tracker so it detects the change
+         if (element._valueTracker) element._valueTracker.setValue('');
+
+         // Dispatch proper InputEvent (not generic Event) for React compatibility
+         element.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
 
          var msg = 'Typed "' + text + '" into ' + selector;
          var count = window.__MCP__.countAll(selector, strategy);

--- a/packages/mcp-server/src/driver/scripts/resolve-ref.js
+++ b/packages/mcp-server/src/driver/scripts/resolve-ref.js
@@ -47,9 +47,22 @@
       }
 
       if (strategy === 'text') {
+         // First try: match element text content
          var xpath = xpathForText(selectorOrRef);
          var result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
-         return result.singleNodeValue;
+         if (result.singleNodeValue) return result.singleNodeValue;
+
+         // Fallback: search placeholder, aria-label, and title attributes
+         var attrSelectors = [
+            '[placeholder*="' + selectorOrRef.replace(/"/g, '\\"') + '"]',
+            '[aria-label*="' + selectorOrRef.replace(/"/g, '\\"') + '"]',
+            '[title*="' + selectorOrRef.replace(/"/g, '\\"') + '"]',
+         ];
+         for (var i = 0; i < attrSelectors.length; i++) {
+            var el = document.querySelector(attrSelectors[i]);
+            if (el) return el;
+         }
+         return null;
       }
 
       if (strategy === 'xpath') {
@@ -78,11 +91,24 @@
       }
 
       if (strategy === 'text') {
+         // First try: match element text content
          var xpath = xpathForText(selector);
          var snapshot = document.evaluate(xpath, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
          var results = [];
          for (var i = 0; i < snapshot.snapshotLength; i++) {
             results.push(snapshot.snapshotItem(i));
+         }
+         if (results.length > 0) return results;
+
+         // Fallback: search placeholder, aria-label, and title attributes
+         var attrSelectors = [
+            '[placeholder*="' + selector.replace(/"/g, '\\"') + '"]',
+            '[aria-label*="' + selector.replace(/"/g, '\\"') + '"]',
+            '[title*="' + selector.replace(/"/g, '\\"') + '"]',
+         ];
+         for (var i = 0; i < attrSelectors.length; i++) {
+            var found = Array.from(document.querySelectorAll(attrSelectors[i]));
+            if (found.length > 0) return results.concat(found);
          }
          return results;
       }

--- a/packages/mcp-server/src/driver/webview-executor.ts
+++ b/packages/mcp-server/src/driver/webview-executor.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { connectPlugin } from './plugin-client.js';
-import { hasActiveSession, getDefaultSession, resolveTargetApp } from './session-manager.js';
+import { hasActiveSession, getDefaultSession, resolveTargetApp, manageDriverSession } from './session-manager.js';
 import { createMcpLogger } from '../logger.js';
 import {
    buildScreenshotScript,
@@ -47,11 +47,15 @@ export async function ensureReady(): Promise<void> {
       return;
    }
 
-   // Require an active session to prevent connecting to wrong app
+   // Auto-connect if no active session
    if (!hasActiveSession()) {
-      throw new Error(
-         'No active session. Call driver_session with action "start" first to connect to a Tauri app.'
-      );
+      const result = await manageDriverSession('start');
+
+      if (!hasActiveSession()) {
+         throw new Error(
+            'Auto-connect failed: ' + result + '. Call driver_session with action "start" to connect manually.'
+         );
+      }
    }
 
    // Get default session for initial connection

--- a/packages/mcp-server/src/driver/webview-interactions.ts
+++ b/packages/mcp-server/src/driver/webview-interactions.ts
@@ -35,7 +35,8 @@ export const WindowTargetSchema = z.object({
  */
 const selectorStrategyField = z.enum([ 'css', 'xpath', 'text' ]).default('css').describe(
    'Selector strategy: "css" (default) for CSS selectors, "xpath" for XPath expressions, ' +
-   '"text" to find elements containing the given text. Ref IDs (e.g., "ref=e3") work with any strategy.'
+   '"text" to find elements by text content, with fallback to placeholder, aria-label, ' +
+   'and title attributes. Ref IDs (e.g., "ref=e3") work with any strategy.'
 );
 
 // ============================================================================

--- a/packages/mcp-server/src/tools-registry.ts
+++ b/packages/mcp-server/src/tools-registry.ts
@@ -258,6 +258,7 @@ export const TOOLS: ToolDefinition[] = [
       description:
          '[Tauri Apps Only] Find DOM elements in a running Tauri app\'s webview. ' +
          'Supports CSS selectors (default), XPath expressions, and text content matching via the strategy parameter. ' +
+         'The "text" strategy first searches element text content, then falls back to placeholder, aria-label, and title attributes. ' +
          'Returns the element\'s HTML. ' +
          'Requires active driver_session. ' +
          MULTI_APP_DESC + ' ' +


### PR DESCRIPTION
## Summary

- **React-compatible text input**: The `webview_interact` type action now uses the native `HTMLInputElement.prototype.value` setter and dispatches `InputEvent` (instead of a generic `Event`) to correctly trigger React's synthetic event system. Previously, directly setting `.value` bypassed React's internal value tracker, causing controlled components to silently ignore typed input.
- **Enhanced "text" selector strategy**: When no element is found by text content, the resolver now falls back to searching `placeholder`, `aria-label`, and `title` attributes. This makes the `text` strategy much more useful for finding form inputs and interactive elements that don't have visible text content.
- **Auto-connect on first tool call**: Instead of throwing an error when no active `driver_session` exists, `ensureReady()` now automatically attempts to start a session. This removes a common friction point where every tool call required a manual `driver_session` start first, while still providing a clear error if auto-connect fails.

## Why these changes?

1. **React is the most popular frontend framework** used in Tauri apps. The previous text input implementation silently failed on React controlled inputs because React tracks value changes through its own internal mechanism. By using the native prototype setter and resetting React's `_valueTracker`, we ensure the input works across vanilla JS, React, Vue, and other frameworks.

2. **Form inputs rarely have visible text content**. The `text` strategy was limited to matching `textContent`, which excluded `<input>` and `<textarea>` elements. Falling back to `placeholder`, `aria-label`, and `title` attributes makes it natural to say "find the element with text 'Search...'" and have it locate an input with that placeholder.

3. **Requiring manual `driver_session` start before every interaction** was an unnecessary step when there's typically only one Tauri app running. Auto-connect eliminates this friction while still failing clearly if no app is available.

## Test plan

- [ ] Test text input on a React app with controlled `<input>` components
- [ ] Test text input on a vanilla JS app to ensure no regression
- [ ] Test `text` strategy finding elements by placeholder text
- [ ] Test `text` strategy finding elements by `aria-label`
- [ ] Test auto-connect when calling a tool without an active session
- [ ] Test auto-connect error message when no Tauri app is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)