### PR TITLE
Fix GitHub CI lint and formatting errors

### DIFF
--- a/packages/mcp-server/src/prompts-registry.ts
+++ b/packages/mcp-server/src/prompts-registry.ts
@@ -3,7 +3,6 @@
  * Prompts are user-controlled templates that appear as slash commands in MCP clients
  */
 
-import { PLUGIN_VERSION_CARGO } from './version.js';
 import { SETUP_INSTRUCTIONS as SETUP_PROMPT } from './constants.js';
 
 export interface PromptArgument {
@@ -49,7 +48,6 @@ Please follow these steps:
 If no errors are found, let me know the app is running cleanly.
 
 If the session fails to start, help me troubleshoot the connection (is the app running? is the MCP bridge plugin installed?).`;
-
 
 
 const SELECT_ELEMENT_PROMPT = (message?: string): string => {
@@ -106,7 +104,6 @@ export const PROMPTS: PromptDefinition[] = [
          ];
       },
    },
-
    {
       name: 'select',
       description:
@@ -132,7 +129,6 @@ export const PROMPTS: PromptDefinition[] = [
          ];
       },
    },
-
    {
       name: 'setup',
       description:

--- a/packages/mcp-server/src/tools-registry.ts
+++ b/packages/mcp-server/src/tools-registry.ts
@@ -29,7 +29,6 @@ import {
    selectElement, getPointedElement,
    SelectElementSchema, GetPointedElementSchema,
 } from './driver/element-picker.js';
-import { PLUGIN_VERSION_CARGO } from './version.js';
 import { SETUP_INSTRUCTIONS } from './constants.js';
 
 /**
@@ -103,7 +102,6 @@ export const TOOL_CATEGORIES = {
 } as const;
 
 
-
 /**
  * Complete registry of all available tools
  * This is the single source of truth for tool definitions
@@ -132,7 +130,6 @@ export const TOOLS: ToolDefinition[] = [
          return SETUP_INSTRUCTIONS;
       },
    },
-
    // Mobile Development Tools
    {
       name: 'list_devices',
@@ -153,7 +150,6 @@ export const TOOLS: ToolDefinition[] = [
          return `Android Devices:\n${devices.android.join('\n') || 'None'}\n\niOS Booted Simulators:\n${devices.ios.join('\n') || 'None'}`;
       },
    },
-
    // UI Automation Tools
    {
       name: 'driver_session',
@@ -184,7 +180,6 @@ export const TOOLS: ToolDefinition[] = [
          return await manageDriverSession(parsed.action, parsed.host, parsed.port, parsed.appIdentifier);
       },
    },
-
    {
       name: 'webview_find_element',
       description:
@@ -213,7 +208,6 @@ export const TOOLS: ToolDefinition[] = [
          });
       },
    },
-
    {
       name: 'read_logs',
       description:
@@ -234,7 +228,6 @@ export const TOOLS: ToolDefinition[] = [
          return await readLogs(parsed);
       },
    },
-
    // WebView Interaction Tools
    {
       name: 'webview_interact',
@@ -258,7 +251,6 @@ export const TOOLS: ToolDefinition[] = [
          return await interact(parsed);
       },
    },
-
    {
       name: 'webview_screenshot',
       description:
@@ -295,7 +287,6 @@ export const TOOLS: ToolDefinition[] = [
          return result.content;
       },
    },
-
    {
       name: 'webview_keyboard',
       description:
@@ -335,7 +326,6 @@ export const TOOLS: ToolDefinition[] = [
          });
       },
    },
-
    {
       name: 'webview_wait_for',
       description:
@@ -364,7 +354,6 @@ export const TOOLS: ToolDefinition[] = [
          });
       },
    },
-
    {
       name: 'webview_get_styles',
       description:
@@ -393,7 +382,6 @@ export const TOOLS: ToolDefinition[] = [
          });
       },
    },
-
    {
       name: 'webview_execute_js',
       description:
@@ -422,7 +410,6 @@ export const TOOLS: ToolDefinition[] = [
          });
       },
    },
-
    {
       name: 'webview_dom_snapshot',
       description:
@@ -457,7 +444,6 @@ export const TOOLS: ToolDefinition[] = [
          });
       },
    },
-
    // Element Picker Tools
    {
       name: 'webview_select_element',
@@ -486,7 +472,6 @@ export const TOOLS: ToolDefinition[] = [
          });
       },
    },
-
    {
       name: 'webview_get_pointed_element',
       description:
@@ -513,7 +498,6 @@ export const TOOLS: ToolDefinition[] = [
          });
       },
    },
-
    // IPC & Plugin Tools
    {
       name: 'ipc_execute_command',
@@ -539,7 +523,6 @@ export const TOOLS: ToolDefinition[] = [
          });
       },
    },
-
    {
       name: 'ipc_monitor',
       description:
@@ -561,7 +544,6 @@ export const TOOLS: ToolDefinition[] = [
          return await manageIPCMonitoring(parsed.action, parsed.appIdentifier);
       },
    },
-
    {
       name: 'ipc_get_captured',
       description:
@@ -581,7 +563,6 @@ export const TOOLS: ToolDefinition[] = [
          return await getIPCEvents(parsed.filter, parsed.appIdentifier);
       },
    },
-
    {
       name: 'ipc_emit_event',
       description:
@@ -602,7 +583,6 @@ export const TOOLS: ToolDefinition[] = [
          return await emitTestEvent(parsed.eventName, parsed.payload, parsed.appIdentifier);
       },
    },
-
    {
       name: 'ipc_get_backend_state',
       description:
@@ -622,7 +602,6 @@ export const TOOLS: ToolDefinition[] = [
          return await getBackendState({ appIdentifier: parsed.appIdentifier });
       },
    },
-
    // Window Management Tools
    {
       name: 'manage_window',

--- a/packages/tauri-plugin-mcp-bridge/src/commands/script_injection.rs
+++ b/packages/tauri-plugin-mcp-bridge/src/commands/script_injection.rs
@@ -56,4 +56,3 @@ pub async fn request_script_injection<R: Runtime>(
         "scriptIds": scripts.iter().map(|s| s.id.clone()).collect::<Vec<_>>()
     }))
 }
-

--- a/packages/tauri-plugin-mcp-bridge/src/websocket.rs
+++ b/packages/tauri-plugin-mcp-bridge/src/websocket.rs
@@ -808,7 +808,6 @@ fn clear_scripts_from_window<R: Runtime>(window: &WebviewWindow<R>) -> Result<()
         .map_err(|e| format!("Failed to clear scripts: {e}"))
 }
 
-
 /// Clears all MCP-managed scripts from the webview DOM.
 /// Returns window context for the response.
 fn clear_scripts_from_webview<R: Runtime>(


### PR DESCRIPTION
I have fixed several linting and formatting issues that were likely causing the GitHub CI failures on the main branch.

Key changes:
1.  **TypeScript Linting**: Removed unused `PLUGIN_VERSION_CARGO` imports and fixed whitespace issues in `packages/mcp-server/src/prompts-registry.ts` and `packages/mcp-server/src/tools-registry.ts`.
2.  **Rust Formatting**: Ran `cargo fmt` in `packages/tauri-plugin-mcp-bridge` to fix formatting inconsistencies.
3.  **Verification**: Verified that `npm run eslint` and `cargo fmt -- --check` now pass successfully. Unit tests for both the MCP server and the Rust plugin also pass.
4.  **Cleanup**: Removed a large log file (`packages/test-app/tauri_dev.log`) that was accidentally created during the investigation.

---
*PR created automatically by Jules for task [2257419898391673200](https://jules.google.com/task/2257419898391673200) started by @yokuze*