### PR TITLE
feat: route MCP tool calls by host-process CWD when multiple apps are connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `tauri-plugin-mcp-bridge`: `get_backend_state` now includes the host process's current working directory (`cwd` field). Lets MCP clients disambiguate concurrent Tauri instances running from different worktrees or checkouts.
+- `tauri-mcp-server`: `resolveTargetApp` falls back to CWD-based routing when no `appIdentifier` is passed and multiple apps are connected, picking the session whose `cwd` best matches `MCP_BRIDGE_CWD` or `process.cwd()`. Removes the need to manually pass `appIdentifier` per-tool-call when working across multiple worktrees with their own MCP sessions.
+- `tauri-mcp-server`: new `getCwdHint()` config helper and `MCP_BRIDGE_CWD` env override.
+- `driver_session` status output now includes the `cwd` of each connected app.
+
 ## [0.11.2] - 2026-05-19
 
 ### Changed

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -38,6 +38,33 @@ export function getDefaultPort(): number {
 }
 
 /**
+ * Gets the CWD hint used to route tool calls to the right Tauri instance
+ * when multiple are connected at once.
+ *
+ * Resolution priority:
+ * 1. MCP_BRIDGE_CWD environment variable (explicit override; useful when a
+ *    wrapper script wants to pin routing to a specific worktree regardless
+ *    of where the TS server happened to be launched from)
+ * 2. process.cwd() (natural inheritance from the calling shell / IDE)
+ *
+ * Returns null only when both are unavailable, which is extremely rare:
+ * process.cwd() is set on every healthy POSIX process.
+ */
+export function getCwdHint(): string | null {
+   // eslint-disable-next-line no-process-env
+   const override = process.env.MCP_BRIDGE_CWD;
+
+   if (override && override.length > 0) {
+      return override;
+   }
+   try {
+      return process.cwd();
+   } catch {
+      return null;
+   }
+}
+
+/**
  * Gets the full bridge configuration from environment variables.
  */
 export function getConfig(): BridgeConfig {

--- a/packages/mcp-server/src/driver/protocol.ts
+++ b/packages/mcp-server/src/driver/protocol.ts
@@ -129,6 +129,13 @@ export interface BackendState {
       visible: boolean;
    }>;
    window_count: number;
+   /**
+    * Working directory of the host Tauri process. Optional for backward
+    * compat with plugin versions before this field was added. Used by the
+    * TS server to disambiguate concurrent Tauri instances (e.g. moss
+    * running from multiple worktrees) that share the same bundle id.
+    */
+   cwd?: string | null;
    timestamp: number;
 }
 

--- a/packages/mcp-server/src/driver/session-manager.ts
+++ b/packages/mcp-server/src/driver/session-manager.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { getDefaultHost, getDefaultPort } from '../config.js';
+import { getCwdHint, getDefaultHost, getDefaultPort } from '../config.js';
 import { AppDiscovery } from './app-discovery.js';
 import { PluginClient } from './plugin-client.js';
 import { resetInitialization } from './webview-executor.js';
@@ -42,6 +42,13 @@ export const ManageDriverSessionSchema = z.object({
 export interface SessionInfo {
    name: string;
    identifier: string | null;
+   /**
+    * Working directory of the host Tauri process at session-start time.
+    * `null` when the plugin is too old to advertise it (pre-v0.11) or
+    * when the lookup failed; in that case CWD-based routing skips this
+    * session and falls back to default behavior.
+    */
+   cwd: string | null;
    host: string;
    port: number;
    client: PluginClient;
@@ -104,8 +111,71 @@ function getAppDiscovery(host: string): AppDiscovery {
 }
 
 /**
+ * Find the session whose `cwd` best matches `hintCwd`.
+ *
+ * Used to disambiguate multiple concurrent Tauri instances when the caller
+ * did not pass an explicit appIdentifier. The "best match" is the longest
+ * shared prefix between the hint and a session's CWD, in either direction:
+ *
+ *   - `session.cwd === hintCwd` (exact)
+ *   - `hintCwd.startsWith(session.cwd + '/')` (TS server runs inside a
+ *     subdirectory of the host process's CWD; rare)
+ *   - `session.cwd.startsWith(hintCwd + '/')` (host process runs inside
+ *     the workspace the TS server was launched from; the common case
+ *     when VSCode opens a parent dir and moss runs from a worktree)
+ *
+ * Sessions whose `cwd` is null (older plugin without CWD support) are
+ * skipped — they cannot be matched and stay eligible for the existing
+ * "use default app" fallback in `resolveTargetApp`.
+ *
+ * Pure function (takes `sessions` as a parameter) so it can be unit-tested
+ * without touching module state.
+ *
+ * @returns The best-matching session, or null if no session matches.
+ */
+export function findSessionByCwd(
+   sessions: Iterable<SessionInfo>,
+   hintCwd: string | null
+): SessionInfo | null {
+   if (!hintCwd) {
+      return null;
+   }
+
+   let best: SessionInfo | null = null;
+   let bestScore = -1;
+
+   for (const session of sessions) {
+      if (!session.cwd) continue;
+
+      let score = -1;
+
+      if (session.cwd === hintCwd) {
+         score = session.cwd.length;
+      } else if (hintCwd.startsWith(session.cwd + '/')) {
+         score = session.cwd.length;
+      } else if (session.cwd.startsWith(hintCwd + '/')) {
+         score = hintCwd.length;
+      }
+
+      if (score > bestScore) {
+         best = session;
+         bestScore = score;
+      }
+   }
+
+   return best;
+}
+
+/**
  * Resolve target app from port or identifier.
  * Returns the appropriate session based on the routing logic.
+ *
+ * Order of precedence:
+ * 1. Explicit `portOrIdentifier` (port number or bundle id)
+ * 2. CWD match via `findSessionByCwd` against `MCP_BRIDGE_CWD` or
+ *    `process.cwd()` — lets each MCP client target the Tauri instance
+ *    running in its own workspace/worktree without manual routing
+ * 3. The default app (most-recently-connected)
  */
 export function resolveTargetApp(portOrIdentifier?: string | number): SessionInfo {
    if (activeSessions.size === 0) {
@@ -147,6 +217,14 @@ export function resolveTargetApp(portOrIdentifier?: string | number): SessionInf
       }
 
       throw new Error(formatAppNotFoundError(portOrIdentifier));
+   }
+
+   // No explicit identifier: try CWD-based routing before falling back to
+   // "default app". If no session matches, behave as before.
+   const cwdMatch = findSessionByCwd(activeSessions.values(), getCwdHint());
+
+   if (cwdMatch) {
+      return cwdMatch;
    }
 
    // Use default app
@@ -230,6 +308,7 @@ async function handleStatusAction(): Promise<string> {
          connected: true,
          app: session.name,
          identifier: session.identifier,
+         cwd: session.cwd,
          host: session.host,
          port: session.port,
       });
@@ -239,6 +318,7 @@ async function handleStatusAction(): Promise<string> {
       return {
          name: session.name,
          identifier: session.identifier,
+         cwd: session.cwd,
          host: session.host,
          port: session.port,
          isDefault: session.port === defaultPort,
@@ -302,11 +382,12 @@ async function handleStartAction(host?: string, port?: number): Promise<string> 
 
    await client.connect();
 
-   const identifier = await fetchAppIdentifier(client);
+   const { identifier, cwd } = await fetchAppMetadata(client);
 
    const sessionInfo: SessionInfo = {
       name: connectedSession.name,
       identifier,
+      cwd,
       host: connectedSession.host,
       port: connectedSession.port,
       client,
@@ -380,12 +461,18 @@ async function tryConnect(host: string, port: number): Promise<{ name: string; h
  * Must be called after a PluginClient is connected.
  *
  * @param client - The PluginClient to query
- * @returns The app identifier (bundle ID) or null if not available. Returns null when:
- *          - The plugin doesn't support the identifier field (older versions)
+ * @returns `{ identifier, cwd }`. Each field is null when:
+ *          - The plugin is too old to advertise it
  *          - The backend state request fails
- *          - The identifier field is missing from the response
+ *          - The field is missing from the response
+ *
+ *          Older plugins (pre-identifier) return `{ identifier: null, cwd: null }`.
+ *          Newer plugins without the cwd field return a real identifier and a null cwd.
+ *          Routing degrades gracefully in either case.
  */
-async function fetchAppIdentifier(client: PluginClient): Promise<string | null> {
+async function fetchAppMetadata(
+   client: PluginClient
+): Promise<{ identifier: string | null; cwd: string | null }> {
    try {
       const response = await client.sendCommand({
          command: 'invoke_tauri',
@@ -393,16 +480,20 @@ async function fetchAppIdentifier(client: PluginClient): Promise<string | null> 
       });
 
       if (!response.success || !response.data) {
-         return null;
+         return { identifier: null, cwd: null };
       }
 
-      const state = response.data as { app?: { identifier?: string } };
+      const state = response.data as {
+         app?: { identifier?: string };
+         cwd?: string | null;
+      };
 
-      // Return null if identifier is not present (backward compat with older plugins)
-      return state.app?.identifier ?? null;
-   } catch{
-      // Return null on any error (e.g., older plugin version that doesn't support this)
-      return null;
+      return {
+         identifier: state.app?.identifier ?? null,
+         cwd: typeof state.cwd === 'string' && state.cwd.length > 0 ? state.cwd : null,
+      };
+   } catch {
+      return { identifier: null, cwd: null };
    }
 }
 

--- a/packages/mcp-server/tests/unit/config.test.ts
+++ b/packages/mcp-server/tests/unit/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import { getDefaultHost, getDefaultPort, getConfig, buildWebSocketURL } from '../../src/config.js';
+import { getCwdHint, getDefaultHost, getDefaultPort, getConfig, buildWebSocketURL } from '../../src/config.js';
 
 describe('config', () => {
    const originalEnv = process.env;
@@ -11,6 +11,7 @@ describe('config', () => {
       process.env = { ...originalEnv };
       delete process.env.MCP_BRIDGE_HOST;
       delete process.env.MCP_BRIDGE_PORT;
+      delete process.env.MCP_BRIDGE_CWD;
       delete process.env.TAURI_DEV_HOST;
    });
 
@@ -92,6 +93,24 @@ describe('config', () => {
 
       it('builds correct URL for 0.0.0.0', () => {
          expect(buildWebSocketURL('0.0.0.0', 9223)).toBe('ws://0.0.0.0:9223');
+      });
+   });
+
+   describe('getCwdHint', () => {
+      it('returns process.cwd() when no env var is set', () => {
+         expect(getCwdHint()).toBe(process.cwd());
+      });
+
+      it('returns MCP_BRIDGE_CWD when set', () => {
+         process.env.MCP_BRIDGE_CWD = '/some/worktree/path';
+
+         expect(getCwdHint()).toBe('/some/worktree/path');
+      });
+
+      it('ignores an empty MCP_BRIDGE_CWD and falls back to process.cwd()', () => {
+         process.env.MCP_BRIDGE_CWD = '';
+
+         expect(getCwdHint()).toBe(process.cwd());
       });
    });
 });

--- a/packages/mcp-server/tests/unit/session-manager.test.ts
+++ b/packages/mcp-server/tests/unit/session-manager.test.ts
@@ -93,4 +93,117 @@ describe('Session Manager Unit Tests', () => {
          expect(portField.description).toContain('9223');
       });
    });
+
+   describe('findSessionByCwd', () => {
+      // Build a minimal SessionInfo from just the cwd + port fields findSessionByCwd reads.
+      // The other fields are present in the type but never inspected by this function.
+      function fakeSession(port: number, cwd: string | null): unknown {
+         return { name: `app-${port}`, identifier: null, cwd, host: 'localhost', port, client: null, connected: true };
+      }
+
+      it('returns null when hintCwd is null', async () => {
+         const { findSessionByCwd } = await import('../../src/driver/session-manager');
+
+         const sessions = [ fakeSession(9223, '/Users/me/proj') ];
+
+         expect(findSessionByCwd(sessions as never, null)).toBeNull();
+      });
+
+      it('returns null when no session has a cwd', async () => {
+         const { findSessionByCwd } = await import('../../src/driver/session-manager');
+
+         const sessions = [ fakeSession(9223, null), fakeSession(9224, null) ];
+
+         expect(findSessionByCwd(sessions as never, '/Users/me/proj')).toBeNull();
+      });
+
+      it('matches an exact-equal session CWD', async () => {
+         const { findSessionByCwd } = await import('../../src/driver/session-manager');
+
+         const sessions = [
+            fakeSession(9223, '/Users/me/proj-a'),
+            fakeSession(9224, '/Users/me/proj-b'),
+         ];
+
+         const match = findSessionByCwd(sessions as never, '/Users/me/proj-b') as { port: number };
+
+         expect(match.port).toBe(9224);
+      });
+
+      it('matches a session whose CWD is a descendant of the hint', async () => {
+         // Common case: VSCode opened the workspace root, moss runs from a worktree
+         // under it. process.cwd() == workspace root, session.cwd == worktree.
+         const { findSessionByCwd } = await import('../../src/driver/session-manager');
+
+         const sessions = [ fakeSession(9223, '/Users/me/workspace/moss/.worktrees/feature-x') ];
+
+         const match = findSessionByCwd(sessions as never, '/Users/me/workspace') as { port: number };
+
+         expect(match.port).toBe(9223);
+      });
+
+      it('matches a session whose CWD is an ancestor of the hint', async () => {
+         // Reverse case: TS server launched from a subdirectory of moss, moss itself
+         // runs from the moss root. The hint is the subdir, session is the parent.
+         const { findSessionByCwd } = await import('../../src/driver/session-manager');
+
+         const sessions = [ fakeSession(9223, '/Users/me/workspace/moss') ];
+
+         const match = findSessionByCwd(
+            sessions as never,
+            '/Users/me/workspace/moss/src-tauri'
+         ) as { port: number };
+
+         expect(match.port).toBe(9223);
+      });
+
+      it('prefers the deeper (more specific) match among multiple candidates', async () => {
+         // Two worktrees, the hint sits inside one of them — that one should win
+         // over a session whose CWD is just the shared workspace root.
+         const { findSessionByCwd } = await import('../../src/driver/session-manager');
+
+         const sessions = [
+            fakeSession(9223, '/Users/me/workspace'),                          // ancestor (score=18)
+            fakeSession(9224, '/Users/me/workspace/moss/.worktrees/feature-x'), // exact (score=50)
+         ];
+
+         const match = findSessionByCwd(
+            sessions as never,
+            '/Users/me/workspace/moss/.worktrees/feature-x'
+         ) as { port: number };
+
+         expect(match.port).toBe(9224);
+      });
+
+      it('returns null when no session shares any path prefix with the hint', async () => {
+         const { findSessionByCwd } = await import('../../src/driver/session-manager');
+
+         const sessions = [ fakeSession(9223, '/Users/me/proj-a') ];
+
+         expect(findSessionByCwd(sessions as never, '/Users/me/proj-b')).toBeNull();
+      });
+
+      it('does not match a sibling whose CWD shares a parent but not a path boundary', async () => {
+         // /foo/bar should NOT match /foo/barbaz — the boundary check `+ '/'`
+         // prevents the false positive that a naive startsWith would produce.
+         const { findSessionByCwd } = await import('../../src/driver/session-manager');
+
+         const sessions = [ fakeSession(9223, '/foo/barbaz') ];
+
+         expect(findSessionByCwd(sessions as never, '/foo/bar')).toBeNull();
+      });
+
+      it('skips sessions with null cwd and still finds the one with a real cwd', async () => {
+         const { findSessionByCwd } = await import('../../src/driver/session-manager');
+
+         const sessions = [
+            fakeSession(9223, null),
+            fakeSession(9224, '/Users/me/proj'),
+         ];
+
+         const match = findSessionByCwd(sessions as never, '/Users/me/proj') as { port: number };
+
+         expect(match.port).toBe(9224);
+      });
+   });
 });

--- a/packages/tauri-plugin-mcp-bridge/src/commands/backend_state.rs
+++ b/packages/tauri-plugin-mcp-bridge/src/commands/backend_state.rs
@@ -16,6 +16,7 @@ use tauri::{command, AppHandle, Manager, Runtime};
 ///   - `tauri`: Tauri framework version
 ///   - `environment`: Runtime environment info (debug mode, OS, arch)
 ///   - `windows`: List of window labels and their states
+///   - `cwd`: Current working directory of the host process (string or null)
 ///   - `timestamp`: Current timestamp in milliseconds
 #[command]
 pub async fn get_backend_state<R: Runtime>(app: AppHandle<R>) -> Result<Value, String> {
@@ -39,6 +40,13 @@ pub async fn get_backend_state<R: Runtime>(app: AppHandle<R>) -> Result<Value, S
         })
         .collect();
 
+    // Host-process CWD. Lets MCP clients disambiguate concurrent Tauri
+    // instances running from different worktrees or checkouts (bundle id
+    // is identical across them).
+    let cwd: Option<String> = std::env::current_dir()
+        .ok()
+        .map(|p| p.display().to_string());
+
     Ok(serde_json::json!({
         "app": {
             "name": config.product_name.clone().unwrap_or_else(|| "Unknown".to_string()),
@@ -56,6 +64,7 @@ pub async fn get_backend_state<R: Runtime>(app: AppHandle<R>) -> Result<Value, S
         },
         "windows": windows,
         "window_count": windows.len(),
+        "cwd": cwd,
         "timestamp": current_timestamp(),
     }))
 }


### PR DESCRIPTION
## Summary

When multiple Tauri instances are connected to one MCP server (e.g. an agent that has the same project checked out in several git worktrees, each running its own dev binary), tool calls currently fall back to "most-recently-connected" because every instance advertises the same `appIdentifier` (bundle id). This routinely sends tool calls to the wrong app.

This change teaches the server to route by **host-process CWD**:

- **`tauri-plugin-mcp-bridge`** — `get_backend_state` now includes a top-level `cwd` field containing `std::env::current_dir()` (or `null`). Backward-compatible additive field.
- **`tauri-mcp-server`** — each session stores its app's CWD. `resolveTargetApp` falls back to CWD-based routing before "use default app" when no `appIdentifier` is passed: it picks the session whose `cwd` has the longest path-boundary overlap with `MCP_BRIDGE_CWD || process.cwd()`.
- New `getCwdHint()` config helper following the existing `MCP_BRIDGE_*` env-var convention.
- `driver_session` status output now includes each app's `cwd` for debuggability.

For an MCP client opened in a workspace that contains the worktree where the app is running, `process.cwd()` naturally inherits down (IDE → MCP session → wrapper → TS server), so routing becomes automatic with no per-tool-call `appIdentifier` plumbing. The `MCP_BRIDGE_CWD` env var is the explicit-override escape hatch.

## Design notes

- **Boundary-aware path matching** (`session.cwd === hint` OR `hint.startsWith(session.cwd + '/')` OR `session.cwd.startsWith(hint + '/')`). The `+ '/'` guard prevents `/foo/bar` from matching `/foo/barbaz`.
- **Bidirectional matching** because the TS server may be launched from a parent of the app's CWD (common case: IDE opened at workspace root) or a child of it (rare).
- **Longest-prefix wins** when multiple candidates match, so a worktree match beats a workspace-root match.
- **Skips sessions whose `cwd` is `null`**, so the change is fully backward compatible with plugin versions that don't yet advertise the field. Those sessions stay eligible for the existing "use default app" fallback.
- **Explicit `appIdentifier`** still wins over CWD routing — existing call sites and explicit user intent are unchanged.

## Test plan

- [x] `tauri-plugin-mcp-bridge` `cargo check` clean on the new base.
- [x] TS files I touched typecheck clean under the project's tsconfig.
- [x] 32 unit tests pass via `npm run test:unit` (15 in `config.test.ts` — 3 new for `getCwdHint`; 17 in `session-manager.test.ts` — 9 new for `findSessionByCwd` covering exact match, ancestor, descendant, no-match, boundary-aware non-match, longest-match wins, null-cwd skip).
- [ ] (Manual, reviewer) Launch two Tauri apps from two different directories. Connect both via MCP. From a third terminal whose CWD matches app A, observe the tool call routes to app A. Set `MCP_BRIDGE_CWD` to a non-matching path, observe fallthrough to the default app.

## Notes

- This was first validated in [Symbiosis-Lab/mcp-server-tauri#1](https://github.com/Symbiosis-Lab/mcp-server-tauri/pull/1) (merged) where it solved a multi-Claude-Code-session-per-repo collision on a real moss/Tauri codebase.
- The full-project `npx tsc --noEmit` flags one pre-existing error in [`packages/mcp-server/src/driver/webview-interactions.ts:255`](packages/mcp-server/src/driver/webview-interactions.ts#L255) (`Buffer` vs `writeFile` type incompatibility on Node 24 / TS 5.7+). Same error on `main`; not introduced by this branch.
- CHANGELOG entries added under `[Unreleased]` for the next release to pick up — no version bump in this PR.
- Two scoped commits to match the repo's commitlint convention; happy to squash if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)