### PR TITLE
fix: return JS eval results on Windows/WebView2 (execute_js/dom_snapshot/screenshot time out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `execute_js` (and the `dom_snapshot` / html2canvas-screenshot tools built on it)
+  no longer time out on Windows/WebView2. The non-macOS path relied on a JS->IPC
+  postback (`invoke('plugin:mcp-bridge|script_result')`) that never completes on
+  WebView2 — the same class of failure that #12 fixed for macOS via native eval.
+  Synchronous scripts now use Tauri's `WebviewWindow::eval_with_callback` (a real
+  result channel through WebView2's `ExecuteScript` completion handler); async
+  scripts keep the IPC-callback fallback.
+
 ## [0.11.2] - 2026-05-19
 
 ### Changed

--- a/packages/tauri-plugin-mcp-bridge/src/commands/execute_js.rs
+++ b/packages/tauri-plugin-mcp-bridge/src/commands/execute_js.rs
@@ -54,6 +54,28 @@ pub async fn execute_js<R: Runtime>(
         }
     }
 
+    // Non-macOS (Windows/WebView2, Linux/WebKitGTK): use Tauri's result-returning
+    // `eval_with_callback`, which wires the webview engine's native eval-completion
+    // handler (WebView2 `ICoreWebView2::ExecuteScript`) straight back to Rust —
+    // bypassing the JS->IPC postback (`invoke('plugin:mcp-bridge|script_result')`)
+    // that silently fails on WebView2 (the same "fails on some setups" reason macOS
+    // went native). Synchronous scripts only — the callback captures the script's
+    // sync return value, so async/Promise scripts keep the IPC-callback fallback.
+    #[cfg(not(target_os = "macos"))]
+    {
+        if should_use_callback_evaluation(&script) {
+            match eval_with_native_callback(&window, &script).await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    mcp_log_error(
+                        "EXECUTE_JS",
+                        &format!("eval_with_callback failed, falling back: {e}"),
+                    );
+                }
+            }
+        }
+    }
+
     // Fallback: eval + event listener approach
     eval_with_ipc_callback(&window, &script, &state).await
 }
@@ -174,6 +196,82 @@ fn should_use_native_evaluation(script: &str) -> bool {
         && !trimmed.contains(".then(")
         && !trimmed.contains("Promise.")
         && !trimmed.contains("new Promise(")
+}
+
+/// Non-macOS heuristic mirroring `should_use_native_evaluation`: only take the
+/// synchronous `eval_with_callback` path for scripts without async/Promise, since
+/// the callback captures the script's synchronous return value.
+#[cfg(not(target_os = "macos"))]
+fn should_use_callback_evaluation(script: &str) -> bool {
+    let t = script.trim();
+    !t.contains("await ")
+        && !t.contains("async ")
+        && !t.contains("(async")
+        && !t.contains(".then(")
+        && !t.contains("Promise.")
+        && !t.contains("new Promise(")
+}
+
+/// Non-macOS: evaluate `script` via Tauri's `WebviewWindow::eval_with_callback`,
+/// which JSON-serializes the script's result and hands it back through the webview
+/// engine's native completion handler (WebView2 `ExecuteScript`). No JS->IPC
+/// postback, so it returns reliably on WebView2 where `eval_with_ipc_callback`
+/// hangs. Returns the same `{ success, data }` / `{ success, error }` shape as the
+/// macOS native path.
+#[cfg(not(target_os = "macos"))]
+async fn eval_with_native_callback<R: Runtime>(
+    window: &WebviewWindow<R>,
+    script: &str,
+) -> Result<Value, String> {
+    use std::sync::{Arc, Mutex};
+
+    let prepared_script = prepare_script(script);
+    // Return the actual value (eval_with_callback JSON-serializes it). Wrap in
+    // try/catch and tag errors: WebView2 silently ignores thrown exceptions, so
+    // they must be surfaced as a value (per Tauri's eval_with_callback docs).
+    let wrapped_script = format!(
+        r#"
+        (function() {{
+            try {{
+                var __result = (function() {{ {prepared_script} }})();
+                return (__result === undefined) ? null : __result;
+            }} catch (error) {{
+                return {{ "__mcp_error__": (error && error.message) ? error.message : String(error) }};
+            }}
+        }})()
+        "#
+    );
+
+    let (tx, rx) = oneshot::channel::<String>();
+    let tx = Arc::new(Mutex::new(Some(tx)));
+    let tx_cb = tx.clone();
+    window
+        .eval_with_callback(&wrapped_script, move |json: String| {
+            if let Some(tx) = tx_cb.lock().unwrap().take() {
+                let _ = tx.send(json);
+            }
+        })
+        .map_err(|e| format!("Failed to execute script: {e}"))?;
+
+    match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
+        Ok(Ok(json)) => {
+            // `json` is the JSON-serialized evaluation result.
+            let val: Value = serde_json::from_str(&json).unwrap_or(Value::Null);
+            if let Some(err) = val.get("__mcp_error__").and_then(|v| v.as_str()) {
+                Ok(serde_json::json!({ "success": false, "error": err }))
+            } else {
+                Ok(serde_json::json!({ "success": true, "data": val }))
+            }
+        }
+        Ok(Err(_)) => Ok(serde_json::json!({
+            "success": false,
+            "error": "Script execution failed: channel closed"
+        })),
+        Err(_) => Ok(serde_json::json!({
+            "success": false,
+            "error": "Script execution timeout (callback)"
+        })),
+    }
 }
 
 /// Fallback: eval + IPC event listener approach.


### PR DESCRIPTION
## Problem

On Windows (WebView2), every webview tool that returns a value — `webview_execute_js`, `webview_dom_snapshot`, and the html2canvas / Screen-Capture `webview_screenshot` fallbacks — fails with `WebView execution failed: Request timeout after 2000ms`. The WebSocket transport and all Rust-native commands (`ipc_get_backend_state`, `manage_window`, …) work fine; only the JS-eval result round-trip hangs.

### Root cause

`execute_js` forks by OS. macOS uses native `WKWebView evaluateJavaScript:completionHandler:` — added precisely because "the eval-and-IPC-callback approach … fails on some setups." Every other platform falls through to `eval_with_ipc_callback`, which runs a fire-and-forget `window.eval()` whose wrapper posts the result back via `window.__TAURI__.core.invoke('plugin:mcp-bridge|script_result', …)`. On WebView2 that postback never completes, and the wrapper's `.catch` swallows the failure without falling through to the `event.emit` backup — so the Rust `oneshot` never resolves and the server's 2000 ms handshake (`waitForResolveRefHelper`) times out.

In other words, **#12 was not macOS-specific** — the same IPC-callback path also fails on Windows/WebView2; it was only worked around for macOS.

## Fix

Route **synchronous** scripts on non-macOS through Tauri's `WebviewWindow::eval_with_callback`, which hands the JSON-serialized result back through WebView2's `ICoreWebView2::ExecuteScript` completion handler (WebKitGTK on Linux) — a real result channel with no JS→IPC postback, the cross-platform analogue of the macOS native path. Async/Promise scripts keep the existing `eval_with_ipc_callback` fallback, since the callback only captures the script's synchronous return value.

- macOS behavior is unchanged (the new code is `#[cfg(not(target_os = "macos"))]`).
- Returns the same `{ success, data }` / `{ success, error }` shape as the macOS path.

## Verification

Built and run on **Windows 11 (WebView2, Tauri 2.11.2)** against a real Tauri app, via a local path-override of the crate:

- `execute_js` → returns values (e.g. `ok:complete:…:tauri=true`)
- `dom_snapshot` → full element tree with refs
- `screenshot` → native capture succeeds
- `read_logs console` → works

All four previously timed out at 2000 ms.

Related to #12 (extends that macOS fix to Windows/Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
