### PR TITLE
fix: make tool input schemas compatible with JSON Schema draft 2020-12

### DIFF
--- a/packages/mcp-server/src/driver/webview-interactions.ts
+++ b/packages/mcp-server/src/driver/webview-interactions.ts
@@ -97,7 +97,7 @@ export const WaitForSchema = WindowTargetSchema.extend({
 export const GetStylesSchema = WindowTargetSchema.extend({
    selector: z.string().describe('Element selector: CSS selector (default), XPath expression, text content, or ref ID'),
    strategy: selectorStrategyField,
-   properties: z.array(z.string()).optional().describe('Specific CSS properties to retrieve. If omitted, returns all computed styles'),
+   cssProperties: z.array(z.string()).optional().describe('Specific CSS properties to retrieve. If omitted, returns all computed styles'),
    multiple: z.boolean().optional().default(false)
       .describe('Whether to get styles for all matching elements (true) or just the first (false)'),
 });
@@ -338,19 +338,19 @@ export async function waitFor(options: WaitForOptions): Promise<string> {
 export interface GetStylesOptions {
    selector: string;
    strategy?: string;
-   properties?: string[];
+   cssProperties?: string[];
    multiple?: boolean;
    windowId?: string;
    appIdentifier?: string | number;
 }
 
 export async function getStyles(options: GetStylesOptions): Promise<string> {
-   const { selector, strategy, properties, multiple = false, windowId, appIdentifier } = options;
+   const { selector, strategy, cssProperties, multiple = false, windowId, appIdentifier } = options;
 
    const script = buildScript(SCRIPTS.getStyles, {
       selector,
       strategy: strategy ?? 'css',
-      properties: properties || [],
+      properties: cssProperties || [],
       multiple,
    });
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -8,6 +8,37 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
+function fixSchema(obj: Record<string, unknown>): Record<string, unknown> {
+   const result: Record<string, unknown> = {};
+
+   for (const [ k, v ] of Object.entries(obj)) {
+      if (k === '$schema') {
+         continue;
+      }
+      // Bedrock rejects numeric exclusiveMinimum/Maximum (draft 2019-09 syntax)
+      if ((k === 'exclusiveMinimum' || k === 'exclusiveMaximum') && typeof v === 'number') {
+         continue;
+      }
+      if (k === 'type' && Array.isArray(v)) {
+         result.anyOf = (v as string[]).map((t) => { return { type: t }; });
+      } else if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+         result[k] = fixSchema(v as Record<string, unknown>);
+      } else if (Array.isArray(v)) {
+         result[k] = v.map((i) => { return (i !== null && typeof i === 'object' ? fixSchema(i as Record<string, unknown>) : i); });
+      } else {
+         result[k] = v;
+      }
+   }
+   return result;
+}
+
+function toInputSchema(schema: Parameters<typeof zodToJsonSchema>[0]): Record<string, unknown> {
+   const result = fixSchema(zodToJsonSchema(schema) as Record<string, unknown>);
+
+   result.$schema = 'https://json-schema.org/draft/2020-12/schema';
+   return result;
+}
+
 import { TOOLS, TOOL_MAP, ToolResult, ToolContent } from './tools-registry.js';
 import { PROMPTS, PROMPT_MAP } from './prompts-registry.js';
 import { createMcpLogger } from './logger.js';
@@ -32,7 +63,7 @@ export function getCliToolDefinitions(): CliToolDefinition[] {
       return {
          name: tool.name,
          description: tool.description,
-         inputSchema: zodToJsonSchema(tool.schema) as Record<string, unknown>,
+         inputSchema: toInputSchema(tool.schema),
       };
    });
 }
@@ -91,7 +122,7 @@ export function createMcpServer(info: McpServerInfo): Server {
             return {
                name: tool.name,
                description: tool.description,
-               inputSchema: zodToJsonSchema(tool.schema) as Record<string, unknown>,
+               inputSchema: toInputSchema(tool.schema),
                annotations: tool.annotations,
             };
          }),

--- a/packages/mcp-server/src/tools-registry.ts
+++ b/packages/mcp-server/src/tools-registry.ts
@@ -375,7 +375,7 @@ export const TOOLS: ToolDefinition[] = [
          return await getStyles({
             selector: parsed.selector,
             strategy: parsed.strategy,
-            properties: parsed.properties,
+            cssProperties: parsed.cssProperties,
             multiple: parsed.multiple,
             windowId: parsed.windowId,
             appIdentifier: parsed.appIdentifier,


### PR DESCRIPTION
## Summary

Some Claude API relays (e.g. AWS Bedrock-backed) require tool `input_schema` to conform to JSON Schema draft 2020-12 and reject schemas that don't. This PR fixes three issues found through end-to-end testing:

1. **`$schema` pointing to draft-07** — `zod-to-json-schema` defaults to `"http://json-schema.org/draft-07/schema#"`. Replaced with `"https://json-schema.org/draft/2020-12/schema"`.

2. **Array `type` values** — `zod-to-json-schema` emits `"type": ["string", "number"]` for union types. Bedrock rejects array type values; converted to `anyOf: [{type: "string"}, {type: "number"}]`.

3. **Numeric `exclusiveMinimum`/`exclusiveMaximum`** — draft 2019-09 syntax (numeric) is not accepted; these fields are stripped.

4. **`webview_get_styles` parameter named `properties`** — this name conflicts with the JSON Schema `properties` keyword, causing Bedrock's validator to reject the schema. Renamed to `cssProperties`.

All 20 tool schemas now pass end-to-end validation against the API.

## Test Plan

- [x] All 20 tool schemas validated against live Anthropic-compatible API endpoint
- [x] TypeScript build passes (`npm run build`)
- [x] Pre-commit hooks pass (commitlint + eslint + cargo fmt/clippy)

🤖 Generated with [Claude Code](https://claude.ai/code)