### PR TITLE
docs: replace install-mcp with aix add mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,58 +43,16 @@ A **Model Context Protocol (MCP) server** that enables AI assistants like Claude
 
 ### 1. Configure Your AI Assistant
 
-Use [install-mcp](https://www.npmjs.com/package/install-mcp) to add the server to your AI assistant:
+Use [aix](https://aix.a1st.dev/cli/add/#aix-add-mcp) to add the server to your AI assistant:
 
 ```bash
-npx -y install-mcp @hypothesi/tauri-mcp-server --client claude-code
+npx -y @a1st/aix add mcp @hypothesi/tauri-mcp-server --user
 ```
 
 Supported clients: `claude-code`, `cursor`, `windsurf`, `vscode`, `cline`, `roo-cline`, `claude`, `zed`, `goose`, `warp`, `codex`
 
-<details>
-<summary><strong>Claude Code</strong></summary>
-
-```bash
-npx -y install-mcp @hypothesi/tauri-mcp-server --client claude-code
-```
-
-</details>
-
-<details>
-<summary><strong>Cursor</strong></summary>
-
-```bash
-npx -y install-mcp @hypothesi/tauri-mcp-server --client cursor
-```
-
-</details>
-
-<details>
-<summary><strong>VS Code / Copilot</strong></summary>
-
-```bash
-npx -y install-mcp @hypothesi/tauri-mcp-server --client vscode
-```
-
-</details>
-
-<details>
-<summary><strong>Windsurf</strong></summary>
-
-```bash
-npx -y install-mcp @hypothesi/tauri-mcp-server --client windsurf
-```
-
-</details>
-
-<details>
-<summary><strong>Cline</strong></summary>
-
-```bash
-npx -y install-mcp @hypothesi/tauri-mcp-server --client cline
-```
-
-</details>
+> [!TIP]
+> `aix` automatically detects your installed AI assistants and configures them.
 
 **Restart your AI assistant** after adding the configuration.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A **Model Context Protocol (MCP) server** that enables AI assistants like Claude
 Use [aix](https://aix.a1st.dev/cli/add/#aix-add-mcp) to add the server to your AI assistant:
 
 ```bash
-npx -y @a1st/aix add mcp @hypothesi/tauri-mcp-server --user
+npx -y @a1st/aix add mcp tauri --command 'npx @hypothesi/tauri-mcp-server' --user
 ```
 
 Supported clients: `claude-code`, `cursor`, `windsurf`, `vscode`, `cline`, `roo-cline`, `claude`, `zed`, `goose`, `warp`, `codex`

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -96,7 +96,7 @@ Before you begin, ensure you have:
 First, add the MCP server to your AI assistant using [aix](https://aix.a1st.dev/cli/add/#aix-add-mcp):
 
 ```bash
-npx -y @a1st/aix add mcp @hypothesi/tauri-mcp-server --user
+npx -y @a1st/aix add mcp tauri --command 'npx @hypothesi/tauri-mcp-server' --user
 ```
 
 Supported clients: `claude-code`, `cursor`, `windsurf`, `vscode`, `cline`, `roo-cline`, `claude`, `zed`, `goose`, `warp`, `codex`

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -93,10 +93,10 @@ Before you begin, ensure you have:
 
 ## Step 1: Configure Your AI Assistant
 
-First, add the MCP server to your AI assistant using [install-mcp](https://www.npmjs.com/package/install-mcp):
+First, add the MCP server to your AI assistant using [aix](https://aix.a1st.dev/cli/add/#aix-add-mcp):
 
 ```bash
-npx -y install-mcp @hypothesi/tauri-mcp-server --client claude-code
+npx -y @a1st/aix add mcp @hypothesi/tauri-mcp-server --user
 ```
 
 Supported clients: `claude-code`, `cursor`, `windsurf`, `vscode`, `cline`, `roo-cline`, `claude`, `zed`, `goose`, `warp`, `codex`

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,10 +119,10 @@ The npm package `@hypothesi/tauri-plugin-mcp-bridge` is **optional**. It provide
 
 ### 3. Configure Your AI Assistant
 
-Use [install-mcp](https://www.npmjs.com/package/install-mcp) to add the server to your AI assistant:
+Use [aix](https://aix.a1st.dev/cli/add/#aix-add-mcp) to add the server to your AI assistant:
 
 ```bash
-npx -y install-mcp @hypothesi/tauri-mcp-server --client claude-code
+npx -y @a1st/aix add mcp @hypothesi/tauri-mcp-server --user
 ```
 
 Supported clients: `claude-code`, `cursor`, `windsurf`, `vscode`, `cline`, `roo-cline`, `claude`, `zed`, `goose`, `warp`, `codex`

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,7 +122,7 @@ The npm package `@hypothesi/tauri-plugin-mcp-bridge` is **optional**. It provide
 Use [aix](https://aix.a1st.dev/cli/add/#aix-add-mcp) to add the server to your AI assistant:
 
 ```bash
-npx -y @a1st/aix add mcp @hypothesi/tauri-mcp-server --user
+npx -y @a1st/aix add mcp tauri --command 'npx @hypothesi/tauri-mcp-server' --user
 ```
 
 Supported clients: `claude-code`, `cursor`, `windsurf`, `vscode`, `cline`, `roo-cline`, `claude`, `zed`, `goose`, `warp`, `codex`

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -44,10 +44,10 @@ fn main() {
 
 ### 2. Configure Your AI Assistant
 
-Use [install-mcp](https://www.npmjs.com/package/install-mcp) to add the server to your AI assistant:
+Use [aix](https://aix.a1st.dev/cli/add/#aix-add-mcp) to add the server to your AI assistant:
 
 ```bash
-npx -y install-mcp @hypothesi/tauri-mcp-server --client claude-code
+npx -y @a1st/aix add mcp @hypothesi/tauri-mcp-server --user
 ```
 
 Supported clients: `claude-code`, `cursor`, `windsurf`, `vscode`, `cline`, `roo-cline`, `claude`, `zed`, `goose`, `warp`, `codex`

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -47,7 +47,7 @@ fn main() {
 Use [aix](https://aix.a1st.dev/cli/add/#aix-add-mcp) to add the server to your AI assistant:
 
 ```bash
-npx -y @a1st/aix add mcp @hypothesi/tauri-mcp-server --user
+npx -y @a1st/aix add mcp tauri --command 'npx @hypothesi/tauri-mcp-server' --user
 ```
 
 Supported clients: `claude-code`, `cursor`, `windsurf`, `vscode`, `cline`, `roo-cline`, `claude`, `zed`, `goose`, `warp`, `codex`


### PR DESCRIPTION
This change replaces all instances of the `install-mcp` command with `aix add mcp`.
`aix` is a more robust tool for managing AI assistant configurations across multiple editors.

Changes:
- Replaced `[install-mcp](https://www.npmjs.com/package/install-mcp)` with `[aix](https://aix.a1st.dev/cli/add/#aix-add-mcp)`
- Replaced `npx -y install-mcp @hypothesi/tauri-mcp-server --client <client>` with `npx -y @a1st/aix add mcp @hypothesi/tauri-mcp-server --user`
- Consolidated redundant client-specific installation blocks in the root README.md into a single simplified section.
- Updated documentation in:
  - README.md
  - docs/index.md
  - docs/guides/getting-started.md
  - packages/mcp-server/README.md

---
*PR created automatically by Jules for task [1592587288481737353](https://jules.google.com/task/1592587288481737353) started by @yokuze*