### PR TITLE
fix: make screenshot capture safe and bounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `webview_screenshot` no longer opens an interactive screen-sharing permission prompt unless `allowScreenCapture` is explicitly enabled.
+
+### Fixed
+- `tauri-plugin-mcp-bridge`: capture Linux screenshots through WebKitGTK's native visible-region snapshot API.
+- `tauri-mcp-server`: constrain html2canvas fallback output to the visible viewport instead of allocating a full-document canvas.
+
 ## [0.12.0] - 2026-07-05
 
 ### Added

--- a/docs/api/webview-interaction.md
+++ b/docs/api/webview-interaction.md
@@ -90,6 +90,7 @@ Capture a screenshot of the current viewport (visible area) of the webview.
 | `filePath` | string | No | File path to save the screenshot to instead of returning base64 |
 | `windowId` | string | No | Window label to target (defaults to 'main') |
 | `maxWidth` | number | No | Maximum width in pixels. Images wider than this will be scaled down proportionally |
+| `allowScreenCapture` | boolean | No | Allow an interactive OS screen-sharing prompt if native and html2canvas capture fail (default: false) |
 
 ### Example
 
@@ -112,11 +113,19 @@ Capture a screenshot of the current viewport (visible area) of the webview.
   "tool": "webview_screenshot",
   "maxWidth": 800
 }
+
+// Explicitly allow the interactive Screen Capture API fallback
+{
+  "tool": "webview_screenshot",
+  "allowScreenCapture": true
+}
 ```
 
 ### Response
 
 Returns a base64-encoded image, or if `filePath` is provided, returns the path where the screenshot was saved.
+
+The Screen Capture API fallback is disabled by default because it opens an operating-system permission prompt and may share more than the target webview. Set `allowScreenCapture` only when that interactive fallback is desired.
 
 ### Environment Variable
 

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `webview_screenshot` only uses the interactive Screen Capture API fallback when `allowScreenCapture` is explicitly enabled.
+
+### Fixed
+- Constrain html2canvas fallback output to the visible viewport instead of allocating a full-document canvas.
+
 ## [0.12.0] - 2026-07-05
 
 ### Added

--- a/packages/mcp-server/src/driver/scripts/html2canvas-loader.ts
+++ b/packages/mcp-server/src/driver/scripts/html2canvas-loader.ts
@@ -68,14 +68,32 @@ export function buildScreenshotCaptureScript(format: 'png' | 'jpeg', quality: nu
    return `
       ${HTML2CANVAS_RESOLVER_SCRIPT}
 
-      // Capture the entire document
+      // Render the document, but crop the output to the visible viewport. Without
+      // explicit bounds html2canvas allocates a canvas for the full scrollable
+      // document, which is both inconsistent with the native implementations and
+      // can time out on long pages.
       const element = document.documentElement;
       if (!element) {
          throw new Error('document.documentElement is null');
       }
 
+      const viewportWidth = Math.max(element.clientWidth, window.innerWidth || 0);
+      const viewportHeight = Math.max(element.clientHeight, window.innerHeight || 0);
+      const viewportX = window.scrollX || window.pageXOffset || 0;
+      const viewportY = window.scrollY || window.pageYOffset || 0;
+
       // Capture the webview
-      const canvas = await html2canvasFn(element, ${HTML2CANVAS_OPTIONS_SCRIPT});
+      const canvas = await html2canvasFn(element, {
+         ...${HTML2CANVAS_OPTIONS_SCRIPT},
+         x: viewportX,
+         y: viewportY,
+         width: viewportWidth,
+         height: viewportHeight,
+         windowWidth: viewportWidth,
+         windowHeight: viewportHeight,
+         scrollX: viewportX,
+         scrollY: viewportY,
+      });
       if (!canvas) {
          throw new Error('html2canvas returned null canvas');
       }

--- a/packages/mcp-server/src/driver/webview-executor.ts
+++ b/packages/mcp-server/src/driver/webview-executor.ts
@@ -395,6 +395,7 @@ export interface CaptureScreenshotOptions {
    windowId?: string;
    appIdentifier?: string | number;
    maxWidth?: number;
+   allowScreenCapture?: boolean;
 }
 
 /**
@@ -427,13 +428,17 @@ async function prepareHtml2canvasScript(
 }
 
 /**
- * Capture a screenshot of the entire webview.
+ * Capture a screenshot of the visible webview viewport.
  *
  * @param options - Screenshot options (format, quality, windowId, appIdentifier, etc.)
  * @returns Screenshot result with image content
  */
 export async function captureScreenshot(options: CaptureScreenshotOptions = {}): Promise<ScreenshotResult> {
-   const { format = 'jpeg', quality = 80, windowId, appIdentifier, maxWidth } = options;
+   const {
+      format = 'jpeg', quality = 80, windowId, appIdentifier, maxWidth, allowScreenCapture = false,
+   } = options;
+
+   let nativeErrorMsg = 'Native screenshot unavailable';
 
    // Primary implementation: Use native platform-specific APIs
    // - macOS: WKWebView takeSnapshot
@@ -474,9 +479,9 @@ export async function captureScreenshot(options: CaptureScreenshotOptions = {}):
       return buildScreenshotResult(dataUrl, 'native API', response.windowContext);
    } catch(nativeError: unknown) {
       // Log the native error for debugging, then fall back
-      const nativeMsg = nativeError instanceof Error ? nativeError.message : String(nativeError);
+      nativeErrorMsg = nativeError instanceof Error ? nativeError.message : String(nativeError);
 
-      driverLogger.error(`Native screenshot failed: ${nativeMsg}, falling back to html2canvas`);
+      driverLogger.error(`Native screenshot failed: ${nativeErrorMsg}, falling back to html2canvas`);
    }
 
    // Fallback 1: Use html2canvas library for high-quality DOM rendering
@@ -551,6 +556,16 @@ export async function captureScreenshot(options: CaptureScreenshotOptions = {}):
 
       throw new Error(`html2canvas returned invalid result: ${result?.substring(0, 100) || 'null'}`);
    } catch(html2canvasError: unknown) {
+      const html2canvasMsg = html2canvasError instanceof Error ? html2canvasError.message : 'html2canvas failed';
+
+      if (!allowScreenCapture) {
+         throw new Error(
+            `Screenshot capture failed. Native API error: ${nativeErrorMsg}, ` +
+            `html2canvas error: ${html2canvasMsg}. ` +
+            'Screen Capture API fallback is disabled; set allowScreenCapture to true to request interactive permission.'
+         );
+      }
+
       try {
          // Fallback to Screen Capture API
          const result = await executeAsyncInWebview(screenCaptureScript, windowId, 5000, appIdentifier);
@@ -563,12 +578,10 @@ export async function captureScreenshot(options: CaptureScreenshotOptions = {}):
          throw new Error(`Screen Capture API returned invalid result: ${result?.substring(0, 50) || 'null'}`);
       } catch(screenCaptureError: unknown) {
          // All methods failed - throw a proper error
-         const html2canvasMsg = html2canvasError instanceof Error ? html2canvasError.message : 'html2canvas failed';
-
          const screenCaptureMsg = screenCaptureError instanceof Error ? screenCaptureError.message : 'Screen Capture API failed';
 
          throw new Error(
-            'Screenshot capture failed. Native API not available, ' +
+            `Screenshot capture failed. Native API error: ${nativeErrorMsg}, ` +
             `html2canvas error: ${html2canvasMsg}, ` +
             `Screen Capture API error: ${screenCaptureMsg}`
          );
@@ -592,4 +605,7 @@ export const GetConsoleLogsSchema = z.object({
 export const CaptureScreenshotSchema = z.object({
    format: z.enum([ 'png', 'jpeg' ]).optional().default('jpeg').describe('Image format'),
    quality: z.number().min(0).max(100).optional().describe('JPEG quality (0-100)'),
+   allowScreenCapture: z.boolean().optional().default(false).describe(
+      'Allow the Screen Capture API fallback, which opens an interactive OS permission prompt'
+   ),
 });

--- a/packages/mcp-server/src/driver/webview-interactions.ts
+++ b/packages/mcp-server/src/driver/webview-interactions.ts
@@ -70,6 +70,9 @@ export const ScreenshotSchema = WindowTargetSchema.extend({
       'Maximum width in pixels. Images wider than this will be scaled down proportionally. ' +
       'Can also be set via TAURI_MCP_SCREENSHOT_MAX_WIDTH environment variable.'
    ),
+   allowScreenCapture: z.boolean().optional().default(false).describe(
+      'Allow an interactive OS screen-sharing permission prompt if native and html2canvas capture fail'
+   ),
 });
 
 export const KeyboardSchema = WindowTargetSchema.extend({
@@ -226,6 +229,7 @@ export interface ScreenshotOptions {
    filePath?: string;
    appIdentifier?: string | number;
    maxWidth?: number;
+   allowScreenCapture?: boolean;
 }
 
 export interface ScreenshotFileResult {
@@ -234,10 +238,12 @@ export interface ScreenshotFileResult {
 }
 
 export async function screenshot(options: ScreenshotOptions = {}): Promise<ScreenshotResult | ScreenshotFileResult> {
-   const { quality, format = 'jpeg', windowId, filePath, appIdentifier, maxWidth } = options;
+   const { quality, format = 'jpeg', windowId, filePath, appIdentifier, maxWidth, allowScreenCapture } = options;
 
    // Use the native screenshot function from webview-executor
-   const result = await captureScreenshot({ format, quality, windowId, appIdentifier, maxWidth });
+   const result = await captureScreenshot({
+      format, quality, windowId, appIdentifier, maxWidth, allowScreenCapture,
+   });
 
    // If filePath is provided, write to file instead of returning base64
    if (filePath) {

--- a/packages/mcp-server/src/tools-registry.ts
+++ b/packages/mcp-server/src/tools-registry.ts
@@ -276,6 +276,7 @@ export const TOOLS: ToolDefinition[] = [
             filePath: parsed.filePath,
             appIdentifier: parsed.appIdentifier,
             maxWidth: parsed.maxWidth,
+            allowScreenCapture: parsed.allowScreenCapture,
          });
 
          // If saved to file, return text confirmation

--- a/packages/mcp-server/tests/e2e/webview-interactions.test.ts
+++ b/packages/mcp-server/tests/e2e/webview-interactions.test.ts
@@ -188,6 +188,50 @@ describe('Webview Interactions E2E Tests', () => {
             }
          }
       }, TIMEOUT);
+
+      it('should capture the viewport with a large offscreen DOM', async () => {
+         await executeJavaScript({
+            script: `
+               const root = document.createElement('div');
+               const fragment = document.createDocumentFragment();
+
+               root.id = 'screenshot-stress-test';
+               for (let index = 0; index < 10000; index++) {
+                  const row = document.createElement('div');
+
+                  row.textContent = 'Offscreen row ' + index;
+                  row.style.height = '32px';
+                  fragment.appendChild(row);
+               }
+               root.appendChild(fragment);
+               document.body.appendChild(root);
+               return document.querySelectorAll('*').length;
+            `,
+         });
+
+         try {
+            const result = await screenshot({ format: 'png' });
+
+            expect('content' in result).toBe(true);
+            if (!('content' in result)) {
+               throw new Error('Expected ScreenshotResult with content');
+            }
+
+            const context = result.content.find((item) => { return item.type === 'text'; });
+
+            expect(context?.type).toBe('text');
+            if (process.platform === 'linux' && context?.type === 'text') {
+               expect(context.text).toContain('native API');
+            }
+         } finally {
+            await executeJavaScript({
+               script: `
+                  document.querySelector('#screenshot-stress-test')?.remove();
+                  return true;
+               `,
+            });
+         }
+      }, TIMEOUT);
    });
 
    describe('Keyboard Interactions', () => {

--- a/packages/mcp-server/tests/unit/html2canvas-loader.test.ts
+++ b/packages/mcp-server/tests/unit/html2canvas-loader.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildScreenshotCaptureScript } from '../../src/driver/scripts/html2canvas-loader.js';
+
+describe('html2canvas screenshot script', () => {
+   it('bounds fallback screenshots to the visible viewport', () => {
+      const script = buildScreenshotCaptureScript('png', 80);
+
+      expect(script).toContain('x: viewportX');
+      expect(script).toContain('y: viewportY');
+      expect(script).toContain('width: viewportWidth');
+      expect(script).toContain('height: viewportHeight');
+      expect(script).toContain('windowWidth: viewportWidth');
+      expect(script).toContain('windowHeight: viewportHeight');
+      expect(script).not.toContain('Capture the entire document');
+   });
+});

--- a/packages/mcp-server/tests/unit/webview-executor.test.ts
+++ b/packages/mcp-server/tests/unit/webview-executor.test.ts
@@ -170,4 +170,51 @@ describe('Webview Executor Unit Tests', () => {
          mimeType: 'image/png',
       });
    });
+
+   it('does not request screen-sharing permission without explicit opt-in', async () => {
+      const executor = await import('../../src/driver/webview-executor.js');
+
+      executor.resetInitialization();
+
+      mockSendCommand
+         .mockResolvedValueOnce({ success: true, data: true })
+         .mockResolvedValueOnce({ success: false, error: 'Native screenshot unavailable on Linux' })
+         .mockResolvedValueOnce({ success: false, error: 'Script execution timeout' });
+
+      await expect(executor.captureScreenshot()).rejects.toThrow(
+         'Screen Capture API fallback is disabled'
+      );
+
+      expect(mockSendCommand).toHaveBeenCalledTimes(3);
+
+      const scripts = mockSendCommand.mock.calls
+         .map(([ command ]) => { return command.args?.script; })
+         .filter((script): script is string => { return typeof script === 'string'; });
+
+      expect(scripts.every((script) => { return !script.includes('getDisplayMedia'); })).toBe(true);
+   });
+
+   it('uses Screen Capture API only after explicit opt-in', async () => {
+      const executor = await import('../../src/driver/webview-executor.js');
+
+      executor.resetInitialization();
+
+      mockSendCommand
+         .mockResolvedValueOnce({ success: true, data: true })
+         .mockResolvedValueOnce({ success: false, error: 'Native screenshot unavailable on Linux' })
+         .mockResolvedValueOnce({ success: false, error: 'html2canvas failed' })
+         .mockResolvedValueOnce({ success: true, data: 'data:image/png;base64,ZmFrZQ==' });
+
+      const result = await executor.captureScreenshot({ format: 'png', allowScreenCapture: true });
+
+      expect(mockSendCommand).toHaveBeenCalledTimes(4);
+      expect(mockSendCommand).toHaveBeenLastCalledWith(expect.objectContaining({
+         command: 'execute_js',
+         args: expect.objectContaining({ script: expect.stringContaining('getDisplayMedia') }),
+      }), 7000);
+      expect(result.content[0]).toEqual({
+         type: 'text',
+         text: 'Screenshot captured via Screen Capture API',
+      });
+   });
 });

--- a/packages/tauri-plugin-mcp-bridge/CHANGELOG.md
+++ b/packages/tauri-plugin-mcp-bridge/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Capture Linux screenshots through WebKitGTK's native visible-region snapshot API instead of falling back to JavaScript.
+
 ## [0.12.0] - 2026-07-05
 
 ### Added

--- a/packages/tauri-plugin-mcp-bridge/Cargo.lock
+++ b/packages/tauri-plugin-mcp-bridge/Cargo.lock
@@ -3580,7 +3580,9 @@ version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
  "block2 0.5.1",
+ "cairo-rs",
  "futures-util",
+ "gio",
  "image",
  "jni",
  "objc2 0.5.2",
@@ -3596,6 +3598,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "uuid",
+ "webkit2gtk",
  "webview2-com",
  "windows",
  "windows-core 0.61.2",

--- a/packages/tauri-plugin-mcp-bridge/Cargo.toml
+++ b/packages/tauri-plugin-mcp-bridge/Cargo.toml
@@ -65,15 +65,10 @@ webview2-com = "0.38"
 windows = { version = "0.61", features = ["Win32_System_Com", "Win32_System_Com_StructuredStorage", "Win32_Foundation"] }
 windows-core = "0.61"
 
-# Linux: Native screenshot not yet implemented due to webkit2gtk/glib version conflicts
-# The webkit2gtk crate uses glib 0.18.x while newer GTK crates use 0.20.x
-# Screenshots fall back to JavaScript (html2canvas) on Linux
-# [target.'cfg(target_os = "linux")'.dependencies]
-# gtk = "0.18"
-# webkit2gtk = "2.0"
-# cairo-rs = "0.20"
-# gio = "0.20"
-# glib = "0.20"
+[target.'cfg(target_os = "linux")'.dependencies]
+webkit2gtk = "2.0"
+cairo-rs = { version = "0.18", features = ["png"] }
+gio = "0.18"
 
 # Android: Native screenshot using WebView.draw() via JNI
 [target.'cfg(target_os = "android")'.dependencies]

--- a/packages/tauri-plugin-mcp-bridge/src/screenshot/linux.rs
+++ b/packages/tauri-plugin-mcp-bridge/src/screenshot/linux.rs
@@ -1,20 +1,63 @@
 use super::{Screenshot, ScreenshotError};
 use tauri::{Runtime, WebviewWindow};
 
-/// Linux-specific screenshot implementation
+/// Linux-specific screenshot implementation using WebKitGTK's snapshot API.
 ///
-/// Currently returns an error to trigger the JavaScript fallback (html2canvas).
-/// Native WebKitGTK screenshot support requires matching glib versions between
-/// webkit2gtk and the rest of the GTK ecosystem, which creates version conflicts.
-///
-/// TODO: Implement native screenshot when webkit2gtk updates to glib 0.20+
+/// WebKit renders only the visible region directly into a Cairo surface. This
+/// avoids traversing or rasterizing offscreen DOM content in JavaScript.
 pub fn capture_viewport<R: Runtime>(
-    _window: &WebviewWindow<R>,
+    window: &WebviewWindow<R>,
 ) -> Result<Screenshot, ScreenshotError> {
-    // Return error to trigger JavaScript fallback
-    // The webkit2gtk crate uses glib 0.18.x while newer GTK crates use 0.20.x
-    // This version mismatch prevents native screenshot implementation
-    Err(ScreenshotError::CaptureFailed(
-        "Native Linux screenshot not yet implemented - using JavaScript fallback".to_string(),
-    ))
+    #[cfg(target_os = "linux")]
+    {
+        use std::sync::mpsc;
+        use std::time::Duration;
+        use webkit2gtk::{SnapshotOptions, SnapshotRegion, WebViewExt};
+
+        let (tx, rx) = mpsc::channel::<Result<Screenshot, ScreenshotError>>();
+
+        window
+            .with_webview(move |platform_webview| {
+                let webview = platform_webview.inner();
+
+                webview.snapshot(
+                    SnapshotRegion::Visible,
+                    SnapshotOptions::NONE,
+                    None::<&gio::Cancellable>,
+                    move |result| {
+                        let screenshot = result
+                            .map_err(|error| {
+                                ScreenshotError::CaptureFailed(format!(
+                                    "WebKitGTK snapshot failed: {error}"
+                                ))
+                            })
+                            .and_then(|surface| {
+                                let mut data = Vec::new();
+
+                                surface.write_to_png(&mut data).map_err(|error| {
+                                    ScreenshotError::EncodeFailed(format!(
+                                        "Failed to encode WebKitGTK snapshot as PNG: {error}"
+                                    ))
+                                })?;
+
+                                Ok(Screenshot { data })
+                            });
+
+                        let _ = tx.send(screenshot);
+                    },
+                );
+            })
+            .map_err(|error| {
+                ScreenshotError::CaptureFailed(format!("Failed to access webview: {error}"))
+            })?;
+
+        rx.recv_timeout(Duration::from_secs(10))
+            .map_err(|_| ScreenshotError::Timeout)?
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = window;
+        Err(ScreenshotError::PlatformUnsupported)
+    }
 }

--- a/packages/test-app/src-tauri/Cargo.lock
+++ b/packages/test-app/src-tauri/Cargo.lock
@@ -3998,7 +3998,9 @@ version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
  "block2 0.5.1",
+ "cairo-rs",
  "futures-util",
+ "gio",
  "image",
  "jni",
  "objc2 0.5.2",
@@ -4014,6 +4016,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "uuid",
+ "webkit2gtk",
  "webview2-com",
  "windows",
  "windows-core 0.61.2",


### PR DESCRIPTION
## What changed

- implement native Linux viewport screenshots with WebKitGTK's visible-region snapshot API
- bound the html2canvas fallback to the visible viewport instead of allocating a full-document canvas
- require explicit `allowScreenCapture: true` before invoking the interactive Screen Capture API fallback
- add unit coverage and an E2E stress case with 10,000 offscreen DOM rows

## Why

On Linux, native capture was deliberately disabled by an outdated glib-version constraint. The fallback rendered the entire `document.documentElement`, so long pages could exceed the bridge's JavaScript timeout. After that failure the server automatically called `getDisplayMedia()`, unexpectedly opening a KDE screen-sharing permission prompt.

Tauri 2.9 and WebKitGTK now use the same glib 0.18 dependency line, so native visible-region capture can be enabled without duplicate GTK stacks.

## Validation

- `npm run build`
- `npm test` (152 passed, 1 platform skip)
- `npm run eslint`
- `cargo fmt --check` for plugin and test app
- `cargo clippy --manifest-path packages/tauri-plugin-mcp-bridge/Cargo.toml --all-targets -- -D warnings`
- manual Linux stress run: 10,091 DOM elements, 321,044 px document height, native PNG viewport captured in 89 ms
