### PR TITLE
fix: respect console log line limit

### DIFF
--- a/packages/mcp-server/src/driver/webview-executor.ts
+++ b/packages/mcp-server/src/driver/webview-executor.ts
@@ -273,6 +273,7 @@ export async function initializeConsoleCapture(): Promise<string> {
  *
  * @param filter - Optional regex pattern to filter log messages
  * @param since - Optional ISO timestamp to filter logs after this time
+ * @param lines - Maximum number of newest matching logs to return
  * @param windowId - Optional window label to target (defaults to "main")
  * @param appIdentifier - Optional app identifier to target specific app
  * @returns Formatted console logs as string
@@ -280,10 +281,12 @@ export async function initializeConsoleCapture(): Promise<string> {
 export async function getConsoleLogs(
    filter?: string,
    since?: string,
+   lines?: number,
    windowId?: string,
    appIdentifier?: string | number
 ): Promise<string> {
-   const filterStr = filter ? filter.replace(/'/g, '\\\'') : '';
+   const resolvedLines = lines ?? 50,
+         filterStr = filter ? filter.replace(/'/g, '\\\'') : '';
 
    const sinceStr = since || '';
 
@@ -304,6 +307,8 @@ export async function getConsoleLogs(
             throw new Error('Invalid filter regex: ' + e.message);
          }
       }
+
+      filtered = filtered.slice(-${resolvedLines});
 
       return filtered.map(l =>
          '[ ' + new Date(l.timestamp).toISOString() + ' ] [ ' + l.level.toUpperCase() + ' ] ' + l.message

--- a/packages/mcp-server/src/driver/webview-interactions.ts
+++ b/packages/mcp-server/src/driver/webview-interactions.ts
@@ -450,6 +450,7 @@ export async function findElement(options: FindElementOptions): Promise<string> 
 }
 
 export interface GetConsoleLogsOptions {
+   lines?: number;
    filter?: string;
    since?: string;
    windowId?: string;
@@ -460,10 +461,10 @@ export interface GetConsoleLogsOptions {
  * Get console logs from the webview.
  */
 export async function getConsoleLogs(options: GetConsoleLogsOptions = {}): Promise<string> {
-   const { filter, since, windowId, appIdentifier } = options;
+   const { lines = 50, filter, since, windowId, appIdentifier } = options;
 
    try {
-      return await getConsoleLogsFromCapture(filter, since, windowId, appIdentifier);
+      return await getConsoleLogsFromCapture(filter, since, lines, windowId, appIdentifier);
    } catch(error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
 

--- a/packages/mcp-server/src/monitor/logs.ts
+++ b/packages/mcp-server/src/monitor/logs.ts
@@ -55,7 +55,7 @@ function findAdbPath(): string {
 export const ReadLogsSchema = z.object({
    source: z.enum([ 'console', 'android', 'ios', 'system' ])
       .describe('Log source: "console" for webview JS logs, "android" for logcat, "ios" for simulator, "system" for desktop'),
-   lines: z.number().default(50),
+   lines: z.number().int().positive().default(50),
    filter: z.string().optional().describe('Regex or keyword to filter logs'),
    since: z.string().optional().describe('ISO timestamp to filter logs since (e.g. 2023-10-27T10:00:00Z)'),
    windowId: z.string().optional().describe('Window label for console logs (defaults to "main")'),
@@ -81,7 +81,7 @@ export async function readLogs(options: ReadLogsOptions): Promise<string> {
 
       // Handle console logs (webview JS logs)
       if (source === 'console') {
-         return await getConsoleLogs({ filter, since, windowId, appIdentifier });
+         return await getConsoleLogs({ lines, filter, since, windowId, appIdentifier });
       }
 
       if (source === 'android') {

--- a/packages/mcp-server/tests/e2e/monitor.test.ts
+++ b/packages/mcp-server/tests/e2e/monitor.test.ts
@@ -1,7 +1,30 @@
-import { describe, it, expect } from 'vitest';
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
 import { readLogs } from '../../src/monitor/logs';
+import { manageDriverSession } from '../../src/driver/session-manager';
+import { executeJavaScript } from '../../src/driver/webview-interactions';
+import { getTestAppPort } from '../test-utils';
+
+const createConsoleTag = (description: string): string => { return `${description}-${randomUUID()}`; };
+
+async function emitConsoleMessages(messages: readonly string[]): Promise<void> {
+   await executeJavaScript({
+      script: `
+         ${JSON.stringify(messages)}.forEach((message) => console.log(message));
+         return 'emitted';
+      `,
+   });
+}
 
 describe('Monitor Module E2E', () => {
+   beforeAll(async () => {
+      await manageDriverSession('start', undefined, getTestAppPort());
+   });
+
+   afterAll(async () => {
+      await manageDriverSession('stop');
+   });
+
    describe('Log Reading', () => {
       it('should handle system log source', async () => {
          // System logs should be available on macOS
@@ -16,9 +39,110 @@ describe('Monitor Module E2E', () => {
 
          expect(logs).toBeDefined();
       });
+
+      it('should return the newest requested console log lines in chronological order', async () => {
+         const tag = createConsoleTag('console-lines');
+
+         await emitConsoleMessages([ 1, 2, 3, 4, 5 ].map((index) => { return `${tag}-message-${index}`; }));
+
+         const logs = await readLogs({ source: 'console', lines: 2, filter: tag });
+
+         expect(logs.split('\n')).toEqual([
+            expect.stringContaining(`${tag}-message-4`),
+            expect.stringContaining(`${tag}-message-5`),
+         ]);
+      });
+
+      it('should return no more than 50 console log lines by default', async () => {
+         const tag = createConsoleTag('console-default-lines'),
+               messages = Array.from({ length: 55 }, (_, index) => { return `${tag}-message-${index + 1}`; });
+
+         await emitConsoleMessages(messages);
+
+         const logs = await readLogs({ source: 'console', filter: tag }),
+               lines = logs.split('\n');
+
+         expect(lines).toHaveLength(50);
+         expect(lines[0]).toContain(`${tag}-message-6`);
+         expect(lines[49]).toContain(`${tag}-message-55`);
+      });
    });
 
    describe('Log Filtering', () => {
+      it('should filter console logs before applying the line limit', async () => {
+         const tag = createConsoleTag('console-filter-limit'),
+               noiseTag = createConsoleTag('console-filter-noise');
+
+         await emitConsoleMessages([
+            `${tag}-match-1`,
+            `${noiseTag}-noise-1`,
+            `${tag}-match-2`,
+            `${noiseTag}-noise-2`,
+         ]);
+
+         const logs = await readLogs({ source: 'console', lines: 2, filter: tag });
+
+         expect(logs.split('\n')).toEqual([
+            expect.stringContaining(`${tag}-match-1`),
+            expect.stringContaining(`${tag}-match-2`),
+         ]);
+      });
+
+      it('should preserve console log regex filtering', async () => {
+         const tag = createConsoleTag('console-filter-regex');
+
+         await emitConsoleMessages([
+            `${tag}-keep-alpha`,
+            `${tag}-drop-gamma`,
+            `${tag}-keep-beta`,
+         ]);
+
+         const logs = await readLogs({
+            source: 'console',
+            lines: 10,
+            filter: `${tag}-keep-(alpha|beta)`,
+         });
+
+         expect(logs.split('\n')).toEqual([
+            expect.stringContaining(`${tag}-keep-alpha`),
+            expect.stringContaining(`${tag}-keep-beta`),
+         ]);
+      });
+
+      it('should filter console logs by timestamp before applying the line limit', async () => {
+         const tag = createConsoleTag('console-since-limit'),
+               sinceTime = Date.now() - 5000;
+
+         const entries = [
+            { message: `${tag}-recent-1`, timestamp: sinceTime + 1000 },
+            { message: `${tag}-recent-2`, timestamp: sinceTime + 2000 },
+            { message: `${tag}-old-1`, timestamp: sinceTime - 2000 },
+            { message: `${tag}-old-2`, timestamp: sinceTime - 1000 },
+         ];
+
+         await executeJavaScript({
+            script: `
+               ${JSON.stringify(entries)}.forEach(({ message, timestamp }) => {
+                  console.log(message);
+                  window.__MCP_CONSOLE_LOGS__[window.__MCP_CONSOLE_LOGS__.length - 1].timestamp = timestamp;
+               });
+               return 'emitted';
+            `,
+         });
+
+         const logs = await readLogs({
+            source: 'console',
+            lines: 2,
+            filter: tag,
+            since: new Date(sinceTime).toISOString(),
+         });
+
+         expect(logs.split('\n')).toEqual([
+            expect.stringContaining(`${tag}-recent-1`),
+            expect.stringContaining(`${tag}-recent-2`),
+         ]);
+      });
+
       it('should filter logs with regex pattern', async () => {
          const logs = await readLogs({ source: 'system', lines: 50, filter: 'error|warn' });
 

--- a/packages/mcp-server/tests/unit/logs.test.ts
+++ b/packages/mcp-server/tests/unit/logs.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { ReadLogsSchema } from '../../src/monitor/logs';
+
+describe('Read Logs Schema', () => {
+   it('should default to 50 lines', () => {
+      expect(ReadLogsSchema.parse({ source: 'console' }).lines).toBe(50);
+   });
+
+   it.each([ 0, -1, 1.5 ])('should reject an invalid line limit of %s', (lines) => {
+      expect(() => { return ReadLogsSchema.parse({ source: 'console', lines }); }).toThrow();
+   });
+});


### PR DESCRIPTION
## Bug

`read_logs` exposed a `lines` parameter, but the `source: "console"` branch dropped it when `readLogs` called `getConsoleLogs`. The console retrieval script therefore applied `since` and `filter`, then formatted every matching entry without enforcing a line limit.

In the real test app, five uniquely tagged console messages queried with `lines: 2` returned all five instead of the newest two. Android, iOS, and system-log paths use separate retrieval logic and were not affected.

## Summary

- pass `read_logs.lines` through the complete console-log retrieval chain
- validate the limit as a positive integer while preserving the default of 50
- apply `since` and `filter` before retaining the newest matching entries in chronological order

## Regression coverage

- reproduces five uniquely tagged console messages returning all five for `lines: 2` before the fix
- verifies the fixed result contains exactly messages 4 and 5
- covers the 50-line default, custom limits, filter-before-limit, since-before-limit, chronological order, invalid limits, and existing regex filtering

## Validation

- `npm run build` (using Git Bash as npm's script shell on Windows)
- `npm run test:unit --workspace=@hypothesi/tauri-mcp-server` — 64 passed
- `npm run test:e2e --workspace=@hypothesi/tauri-mcp-server` — 157 passed, 1 skipped
- `npm run standards`

The console and Rust IPC buffer sizes remain intentionally out of scope.