### PR TITLE
fix: recover stale WebSocket sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `tauri-mcp-server`: keep bridge WebSockets alive with ping/pong heartbeats and reconnect stale cached sessions when `driver_session start` is called again.
+
 ## [0.12.0] - 2026-07-05
 
 ### Added

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Keep bridge WebSockets alive with ping/pong heartbeats and reconnect stale cached sessions when `driver_session start` is called again.
+
 ## [0.12.0] - 2026-07-05
 
 ### Added

--- a/packages/mcp-server/src/driver/plugin-client.ts
+++ b/packages/mcp-server/src/driver/plugin-client.ts
@@ -3,6 +3,10 @@ import { EventEmitter } from 'events';
 
 import { buildWebSocketURL, getDefaultHost, getDefaultPort } from '../config.js';
 
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 30000,
+      DEFAULT_HEARTBEAT_TIMEOUT_MS = 10000,
+      DEFAULT_CONNECTION_CHECK_TIMEOUT_MS = 1000;
+
 
 interface PluginCommand {
    id?: string;
@@ -22,6 +26,15 @@ export interface PluginResponse {
    };
 }
 
+export interface PluginClientOptions {
+
+   /** How often to ping an idle bridge connection. */
+   readonly heartbeatIntervalMs?: number;
+
+   /** How long to wait for a heartbeat pong before terminating the socket. */
+   readonly heartbeatTimeoutMs?: number;
+}
+
 /**
  * Client to communicate with the MCP Bridge plugin's WebSocket server
  */
@@ -34,6 +47,11 @@ export class PluginClient extends EventEmitter {
    private _reconnectAttempts = 0;
    private _shouldReconnect = true; // Keep trying forever until explicitly disconnected
    private _reconnectDelay = 1000; // Start with 1s, max 30s
+   private _reconnectTimer: NodeJS.Timeout | null = null;
+   private _heartbeatTimer: NodeJS.Timeout | null = null;
+   private _heartbeatTimeout: NodeJS.Timeout | null = null;
+   private readonly _heartbeatIntervalMs: number;
+   private readonly _heartbeatTimeoutMs: number;
    private _pendingRequests: Map<string, {
       resolve: (value: PluginResponse) => void;
       reject: (reason: Error) => void;
@@ -44,12 +62,15 @@ export class PluginClient extends EventEmitter {
     * Constructor for PluginClient
     * @param host Host address of the WebSocket server
     * @param port Port number of the WebSocket server
+    * @param options Optional connection liveness settings
     */
-   public constructor(host: string, port: number) {
+   public constructor(host: string, port: number, options: PluginClientOptions = {}) {
       super();
       this._host = host;
       this._port = port;
       this._url = buildWebSocketURL(host, port);
+      this._heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+      this._heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? DEFAULT_HEARTBEAT_TIMEOUT_MS;
 
       // CRITICAL: Attach a default error handler to prevent crashes.
       // In Node.js, if an EventEmitter emits 'error' with no listeners, it throws
@@ -96,8 +117,13 @@ export class PluginClient extends EventEmitter {
          this._ws.on('open', () => {
             // Connected to MCP Bridge plugin
             this._reconnectAttempts = 0;
+            this._startHeartbeat();
             this.emit('connected');
             resolve();
+         });
+
+         this._ws.on('pong', () => {
+            this._clearHeartbeatTimeout();
          });
 
          this._ws.on('message', (data: WebSocket.Data) => {
@@ -131,6 +157,7 @@ export class PluginClient extends EventEmitter {
 
          this._ws.on('close', () => {
             // Disconnected from MCP Bridge plugin
+            this._stopHeartbeat();
             this.emit('disconnected');
             this._ws = null;
 
@@ -146,11 +173,18 @@ export class PluginClient extends EventEmitter {
                this._reconnectAttempts++;
                const delay = Math.min(this._reconnectDelay * this._reconnectAttempts, 30000);
 
-               setTimeout(() => {
+               this._reconnectTimer = setTimeout(() => {
+                  this._reconnectTimer = null;
+
+                  if (!this._shouldReconnect) {
+                     return;
+                  }
+
                   this.connect().catch(() => {
                      // Reconnection failed - will retry on next close event
                   });
                }, delay);
+               this._reconnectTimer.unref();
             }
          });
       });
@@ -161,10 +195,84 @@ export class PluginClient extends EventEmitter {
     */
    public disconnect(): void {
       this._shouldReconnect = false; // Prevent auto-reconnect
+      this._stopHeartbeat();
+
+      if (this._reconnectTimer) {
+         clearTimeout(this._reconnectTimer);
+         this._reconnectTimer = null;
+      }
+
       if (this._ws) {
          this._ws.close();
          this._ws = null;
       }
+   }
+
+   /**
+    * Probe the current WebSocket with a ping/pong exchange.
+    *
+    * `readyState === OPEN` is insufficient for half-open TCP connections, so
+    * session reuse calls this before trusting a cached client.
+    */
+   public async checkConnection(timeoutMs = DEFAULT_CONNECTION_CHECK_TIMEOUT_MS): Promise<boolean> {
+      const socket = this._ws;
+
+      if (!socket || socket.readyState !== WebSocket.OPEN) {
+         return false;
+      }
+
+      const openSocket = socket;
+
+      return new Promise<boolean>((resolve) => {
+         const probeState: {
+            settled: boolean;
+            timeout: NodeJS.Timeout | null;
+         } = {
+            settled: false,
+            timeout: null,
+         };
+
+         function finish(isAlive: boolean): void {
+            if (probeState.settled) {
+               return;
+            }
+
+            probeState.settled = true;
+
+            if (probeState.timeout) {
+               clearTimeout(probeState.timeout);
+            }
+
+            openSocket.off('pong', handlePong);
+            openSocket.off('close', handleDisconnect);
+            openSocket.off('error', handleDisconnect);
+            resolve(isAlive);
+         }
+
+         function handlePong(): void {
+            finish(true);
+         }
+
+         function handleDisconnect(): void {
+            finish(false);
+         }
+
+         probeState.timeout = setTimeout(() => { finish(false); }, timeoutMs);
+
+         openSocket.once('pong', handlePong);
+         openSocket.once('close', handleDisconnect);
+         openSocket.once('error', handleDisconnect);
+
+         try {
+            openSocket.ping(undefined, undefined, (error) => {
+               if (error) {
+                  finish(false);
+               }
+            });
+         } catch{
+            finish(false);
+         }
+      });
    }
 
    /**
@@ -237,6 +345,65 @@ export class PluginClient extends EventEmitter {
     */
    public isConnected(): boolean {
       return this._ws?.readyState === WebSocket.OPEN;
+   }
+
+   private _clearHeartbeatTimeout(): void {
+      if (this._heartbeatTimeout) {
+         clearTimeout(this._heartbeatTimeout);
+         this._heartbeatTimeout = null;
+      }
+   }
+
+   private _stopHeartbeat(): void {
+      if (this._heartbeatTimer) {
+         clearInterval(this._heartbeatTimer);
+         this._heartbeatTimer = null;
+      }
+
+      this._clearHeartbeatTimeout();
+   }
+
+   private _startHeartbeat(): void {
+      this._stopHeartbeat();
+
+      this._heartbeatTimer = setInterval(() => {
+         const socket = this._ws;
+
+         if (!socket || socket.readyState !== WebSocket.OPEN) {
+            return;
+         }
+
+         // A previous ping is still unanswered. Terminate instead of letting an
+         // OPEN-but-half-dead socket stay in the session cache indefinitely.
+         if (this._heartbeatTimeout) {
+            socket.terminate();
+            return;
+         }
+
+         this._heartbeatTimeout = setTimeout(() => {
+            this._heartbeatTimeout = null;
+
+            if (this._ws === socket && socket.readyState === WebSocket.OPEN) {
+               socket.terminate();
+            }
+         }, this._heartbeatTimeoutMs);
+         this._heartbeatTimeout.unref();
+
+         try {
+            socket.ping(undefined, undefined, (error) => {
+               if (error && this._ws === socket && socket.readyState === WebSocket.OPEN) {
+                  socket.terminate();
+               }
+            });
+         } catch{
+            this._clearHeartbeatTimeout();
+
+            if (this._ws === socket && socket.readyState === WebSocket.OPEN) {
+               socket.terminate();
+            }
+         }
+      }, this._heartbeatIntervalMs);
+      this._heartbeatTimer.unref();
    }
 }
 

--- a/packages/mcp-server/src/driver/session-manager.ts
+++ b/packages/mcp-server/src/driver/session-manager.ts
@@ -283,6 +283,35 @@ function promoteNextDefault(): void {
    }
 }
 
+/**
+ * Return whether a cached session is responsive, removing it when stale.
+ */
+async function keepResponsiveSession(port: number): Promise<boolean> {
+   const session = activeSessions.get(port);
+
+   if (!session) {
+      return false;
+   }
+
+   try {
+      if (await session.client.checkConnection()) {
+         return true;
+      }
+   } catch{
+      // Treat probe errors like missed pongs and replace the stale client below.
+   }
+
+   session.client.disconnect();
+   activeSessions.delete(port);
+
+   if (port === defaultPort) {
+      promoteNextDefault();
+   }
+
+   sessionLogger.info(`Removed stale session: ${session.name} (${session.host}:${session.port})`);
+   return false;
+}
+
 async function handleStatusAction(): Promise<string> {
    if (activeSessions.size === 0) {
       return JSON.stringify({
@@ -341,7 +370,7 @@ async function handleStartAction(host?: string, port?: number): Promise<string> 
 
    const configuredPort = port ?? getDefaultPort();
 
-   if (activeSessions.has(configuredPort)) {
+   if (await keepResponsiveSession(configuredPort)) {
       return `Already connected to app on port ${configuredPort}`;
    }
 
@@ -381,7 +410,7 @@ async function handleStartAction(host?: string, port?: number): Promise<string> 
       return `Session start failed - no Tauri app found at localhost or ${configuredHost}:${configuredPort}`;
    }
 
-   if (activeSessions.has(connectedSession.port)) {
+   if (await keepResponsiveSession(connectedSession.port)) {
       return `Already connected to app on port ${connectedSession.port}`;
    }
 

--- a/packages/mcp-server/tests/unit/plugin-client-heartbeat.test.ts
+++ b/packages/mcp-server/tests/unit/plugin-client-heartbeat.test.ts
@@ -1,0 +1,104 @@
+import type { AddressInfo } from 'node:net';
+
+import WebSocket, { WebSocketServer } from 'ws';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { PluginClient } from '../../src/driver/plugin-client';
+
+interface TestServer {
+   readonly server: WebSocketServer;
+   readonly sockets: Set<WebSocket>;
+   readonly port: number;
+}
+
+describe('PluginClient heartbeat', () => {
+   const clients: PluginClient[] = [],
+         servers: TestServer[] = [];
+
+   async function createServer(onConnection?: (socket: WebSocket) => void): Promise<TestServer> {
+      const sockets = new Set<WebSocket>(),
+            server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+
+      server.on('connection', (socket) => {
+         sockets.add(socket);
+         socket.on('close', () => { sockets.delete(socket); });
+         onConnection?.(socket);
+      });
+
+      await new Promise<void>((resolve, reject) => {
+         server.once('listening', resolve);
+         server.once('error', reject);
+      });
+
+      const address = server.address() as AddressInfo,
+            testServer = { server, sockets, port: address.port };
+
+      servers.push(testServer);
+      return testServer;
+   }
+
+   function createClient(port: number, heartbeatIntervalMs = 30000, heartbeatTimeoutMs = 10000): PluginClient {
+      const client = new PluginClient('127.0.0.1', port, {
+         heartbeatIntervalMs,
+         heartbeatTimeoutMs,
+      });
+
+      clients.push(client);
+      return client;
+   }
+
+   afterEach(async () => {
+      for (const client of clients.splice(0)) {
+         client.disconnect();
+      }
+
+      await Promise.all(servers.splice(0).map(async ({ server, sockets }) => {
+         for (const socket of sockets) {
+            socket.terminate();
+         }
+
+         await new Promise<void>((resolve) => {
+            server.close(() => { resolve(); });
+         });
+      }));
+   });
+
+   it('confirms a healthy OPEN connection with ping/pong', async () => {
+      const { port } = await createServer(),
+            client = createClient(port);
+
+      await client.connect();
+
+      await expect(client.checkConnection(250)).resolves.toBe(true);
+   });
+
+   it('rejects an OPEN connection that does not return a pong', async () => {
+      const { port } = await createServer((socket) => { socket.pause(); }),
+            client = createClient(port);
+
+      await client.connect();
+
+      expect(client.isConnected()).toBe(true);
+      await expect(client.checkConnection(50)).resolves.toBe(false);
+      expect(client.isConnected()).toBe(true);
+   });
+
+   it('terminates an unresponsive connection after a missed heartbeat', async () => {
+      const { port } = await createServer((socket) => { socket.pause(); }),
+            client = createClient(port, 20, 25);
+
+      const disconnected = new Promise<void>((resolve) => {
+         client.once('disconnected', () => { resolve(); });
+      });
+
+      await client.connect();
+
+      await Promise.race([
+         disconnected,
+         new Promise<void>((_resolve, reject) => {
+            setTimeout(() => { reject(new Error('Heartbeat did not close stale connection')); }, 500);
+         }),
+      ]);
+      expect(client.isConnected()).toBe(false);
+   });
+});

--- a/packages/mcp-server/tests/unit/session-recovery.test.ts
+++ b/packages/mcp-server/tests/unit/session-recovery.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clientMocks = vi.hoisted(() => {
+   return {
+      healthResults: [] as Array<boolean | Error>,
+      instances: [] as Array<{
+         readonly checkConnection: ReturnType<typeof vi.fn>;
+         readonly connect: ReturnType<typeof vi.fn>;
+         readonly disconnect: ReturnType<typeof vi.fn>;
+      }>,
+   };
+});
+
+vi.mock('../../src/driver/plugin-client.js', () => {
+   class PluginClient {
+      public readonly host: string;
+      public readonly port: number;
+
+      public readonly checkConnection = vi.fn(async () => {
+         const result = clientMocks.healthResults.shift() ?? true;
+
+         if (result instanceof Error) {
+            throw result;
+         }
+
+         return result;
+      });
+
+      public readonly connect = vi.fn(() => { return Promise.resolve(); });
+      public readonly disconnect = vi.fn();
+      public readonly sendCommand = vi.fn(async () => {
+         return {
+            success: true,
+            data: {
+               app: { identifier: 'com.hypothesi.test-app' },
+               cwd: '/test/app',
+            },
+         };
+      });
+
+      public constructor(host: string, port: number) {
+         this.host = host;
+         this.port = port;
+         clientMocks.instances.push(this);
+      }
+   }
+
+   return { PluginClient };
+});
+
+vi.mock('../../src/driver/app-discovery.js', () => {
+   class AppDiscovery {
+      public readonly host: string;
+
+      public constructor(host: string) {
+         this.host = host;
+      }
+
+      public async connectToPort(port: number, _appName?: string, host?: string): Promise<{
+         name: string;
+         host: string;
+         port: number;
+      }> {
+         const targetHost = host ?? this.host;
+
+         return {
+            name: `Tauri App (${targetHost}:${port})`,
+            host: targetHost,
+            port,
+         };
+      }
+
+      public async getFirstAvailableApp(): Promise<null> {
+         return null;
+      }
+
+      public disconnectAll(): Promise<void> {
+         return Promise.resolve();
+      }
+   }
+
+   return { AppDiscovery };
+});
+
+describe('driver session stale recovery', () => {
+   beforeEach(() => {
+      vi.resetModules();
+      clientMocks.healthResults.length = 0;
+      clientMocks.instances.length = 0;
+   });
+
+   it('keeps a cached session that responds to a liveness probe', async () => {
+      const { manageDriverSession } = await import('../../src/driver/session-manager');
+
+      await manageDriverSession('start', 'localhost', 9223);
+      const result = await manageDriverSession('start', 'localhost', 9223);
+
+      expect(result).toBe('Already connected to app on port 9223');
+      expect(clientMocks.instances).toHaveLength(1);
+      expect(clientMocks.instances[0]?.checkConnection).toHaveBeenCalledOnce();
+      expect(clientMocks.instances[0]?.disconnect).not.toHaveBeenCalled();
+   });
+
+   it('removes and reconnects a cached session that misses its liveness probe', async () => {
+      const { manageDriverSession } = await import('../../src/driver/session-manager');
+
+      await manageDriverSession('start', 'localhost', 9223);
+      clientMocks.healthResults.push(false);
+
+      const result = await manageDriverSession('start', 'localhost', 9223);
+
+      expect(result).toContain('Session started with app');
+      expect(clientMocks.instances).toHaveLength(2);
+      expect(clientMocks.instances[0]?.checkConnection).toHaveBeenCalledOnce();
+      expect(clientMocks.instances[0]?.disconnect).toHaveBeenCalledOnce();
+      expect(clientMocks.instances[1]?.connect).toHaveBeenCalledOnce();
+   });
+
+   it('reconnects when probing the cached session throws', async () => {
+      const { manageDriverSession } = await import('../../src/driver/session-manager');
+
+      await manageDriverSession('start', 'localhost', 9223);
+      clientMocks.healthResults.push(new Error('Socket closed during ping'));
+
+      const result = await manageDriverSession('start', 'localhost', 9223);
+
+      expect(result).toContain('Session started with app');
+      expect(clientMocks.instances).toHaveLength(2);
+      expect(clientMocks.instances[0]?.disconnect).toHaveBeenCalledOnce();
+      expect(clientMocks.instances[1]?.connect).toHaveBeenCalledOnce();
+   });
+});


### PR DESCRIPTION
## Summary

- add WebSocket ping/pong heartbeats so half-open bridge connections are terminated and reconnected
- probe cached sessions before `driver_session start` returns "Already connected"
- replace stale cached sessions when the probe times out or errors
- cover healthy, half-open, heartbeat-timeout, and stale-session recovery paths

## Verification

- `npm run standards`
- `npx tsc --noEmit -p tsconfig.json` in `packages/mcp-server`
- `npx vitest run --config vitest.config.unit.ts` (66 passed)
- `npx vitest run --config vitest.config.ts tests/e2e/session.test.ts` (9 passed, 1 skipped)

## Build note

`npm run build -w @hypothesi/tauri-mcp-server` completes bundling and TypeScript compilation, then hits the existing Windows portability issue because the build script invokes Unix `cp`/`chmod` commands under `cmd.exe`. This PR does not modify that unrelated packaging script.

Closes #34